### PR TITLE
Gather index info at the same time as table info, rather than later.

### DIFF
--- a/regress/expected/repack.out
+++ b/regress/expected/repack.out
@@ -117,16 +117,16 @@ SELECT * FROM tbl_with_dropped_toast;
 \! pg_repack --dbname=contrib_regression --table=tbl_cluster
 INFO: repacking table "tbl_cluster"
 \! pg_repack --dbname=contrib_regression --table=tbl_badindex
-INFO: repacking table "tbl_badindex"
 WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON tbl_badindex USING btree (n)
+INFO: repacking table "tbl_badindex"
 \! pg_repack --dbname=contrib_regression
 INFO: repacking table "tbl_cluster"
 INFO: repacking table "tbl_only_pkey"
 INFO: repacking table "tbl_gistkey"
 INFO: repacking table "tbl_with_dropped_column"
 INFO: repacking table "tbl_with_dropped_toast"
-INFO: repacking table "tbl_badindex"
 WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON tbl_badindex USING btree (n)
+INFO: repacking table "tbl_badindex"
 INFO: repacking table "tbl_idxopts"
 --
 -- after

--- a/regress/expected/repack.out
+++ b/regress/expected/repack.out
@@ -117,16 +117,16 @@ SELECT * FROM tbl_with_dropped_toast;
 \! pg_repack --dbname=contrib_regression --table=tbl_cluster
 INFO: repacking table "tbl_cluster"
 \! pg_repack --dbname=contrib_regression --table=tbl_badindex
-WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON tbl_badindex USING btree (n)
 INFO: repacking table "tbl_badindex"
+WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON tbl_badindex USING btree (n)
 \! pg_repack --dbname=contrib_regression
 INFO: repacking table "tbl_cluster"
 INFO: repacking table "tbl_only_pkey"
 INFO: repacking table "tbl_gistkey"
 INFO: repacking table "tbl_with_dropped_column"
 INFO: repacking table "tbl_with_dropped_toast"
-WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON tbl_badindex USING btree (n)
 INFO: repacking table "tbl_badindex"
+WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON tbl_badindex USING btree (n)
 INFO: repacking table "tbl_idxopts"
 --
 -- after


### PR DESCRIPTION
This helps avoid possible problems with later strong table locks.