### PR TITLE
Ugly fix to support PostgreSQL 9.4

### DIFF
--- a/bin/pgut/pgut.c
+++ b/bin/pgut/pgut.c
@@ -1210,6 +1210,11 @@ exit_or_abort(int exitcode)
 
 /*
  * unlike the server code, this function automatically extend the buffer.
+ *
+ * TODO: as of http://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=3147acd6
+ * server's API of appendStringInfoVA changed. Should be done the same here
+ * or should this function be removed?
+ * 
  */
 bool
 appendStringInfoVA(StringInfo str, const char *fmt, va_list args)

--- a/lib/pg_repack.sql.in
+++ b/lib/pg_repack.sql.in
@@ -172,7 +172,7 @@ CREATE VIEW repack.tables AS
   SELECT R.oid::regclass AS relname,
          R.oid AS relid,
          R.reltoastrelid AS reltoastrelid,
-         CASE WHEN R.reltoastrelid = 0 THEN 0 ELSE (SELECT reltoastidxid FROM pg_class WHERE oid = R.reltoastrelid) END AS reltoastidxid,
+         CASE WHEN R.reltoastrelid = 0 THEN 0 ELSE (SELECT indexrelid FROM pg_index WHERE indrelid = R.reltoastrelid AND indisvalid) END AS reltoastidxid,
          N.nspname AS schemaname,
          PK.indexrelid AS pkid,
          CK.indexrelid AS ckid,

--- a/lib/pgut/pgut-spi.c
+++ b/lib/pgut/pgut-spi.c
@@ -29,10 +29,11 @@ termStringInfo(StringInfo str)
 static void
 appendStringInfoVA_s(StringInfo str, const char *fmt, va_list args)
 {
-	while (!appendStringInfoVA(str, fmt, args))
+	int needed;
+	while ((needed = appendStringInfoVA(str, fmt, args)) != 0)
 	{
-		/* Double the buffer size and try again. */
-		enlargeStringInfo(str, str->maxlen);
+		/* Increase the buffer size and try again. */
+		enlargeStringInfo(str, needed);
 	}
 }
 


### PR DESCRIPTION
This fix does not have support for multiple TOAST indexes (which may happen with PostgreSQL 9.4 and higher) but at least right now pg_repack could be installed on PostgreSQL 9.4 and regression tests passes. See [this issue](https://github.com/reorg/pg_repack/issues/16) for more details.
If I understand everything right, for full support of several toast indexes function `repack_swap` should be strongly rewritten. Unfortunately, I'm not able to do it.