### PR TITLE
Ugly fix to support PostgreSQL 9.4

### DIFF
--- a/bin/pgut/pgut.c
+++ b/bin/pgut/pgut.c
@@ -1210,6 +1210,11 @@ exit_or_abort(int exitcode)
 
 /*
  * unlike the server code, this function automatically extend the buffer.
+ *
+ * TODO: as of http://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=3147acd6
+ * server's API of appendStringInfoVA changed. Should be done the same here
+ * or should this function be removed?
+ * 
  */
 bool
 appendStringInfoVA(StringInfo str, const char *fmt, va_list args)

--- a/lib/pg_repack.sql.in
+++ b/lib/pg_repack.sql.in
@@ -172,7 +172,7 @@ CREATE VIEW repack.tables AS
   SELECT R.oid::regclass AS relname,
          R.oid AS relid,
          R.reltoastrelid AS reltoastrelid,
-         CASE WHEN R.reltoastrelid = 0 THEN 0 ELSE (SELECT reltoastidxid FROM pg_class WHERE oid = R.reltoastrelid) END AS reltoastidxid,
+         CASE WHEN R.reltoastrelid = 0 THEN 0 ELSE (SELECT indexrelid FROM pg_index WHERE indrelid = R.reltoastrelid) END AS reltoastidxid,
          N.nspname AS schemaname,
          PK.indexrelid AS pkid,
          CK.indexrelid AS ckid,

--- a/lib/pgut/pgut-spi.c
+++ b/lib/pgut/pgut-spi.c
@@ -29,11 +29,20 @@ termStringInfo(StringInfo str)
 static void
 appendStringInfoVA_s(StringInfo str, const char *fmt, va_list args)
 {
+#if PG_VERSION_NUM < 90400
 	while (!appendStringInfoVA(str, fmt, args))
 	{
 		/* Double the buffer size and try again. */
 		enlargeStringInfo(str, str->maxlen);
 	}
+#else
+	int needed;
+	while ((needed = appendStringInfoVA(str, fmt, args)) != 0)
+	{
+		/* Increase the buffer size and try again. */
+		enlargeStringInfo(str, needed);
+	}
+#endif
 }
 
 /* simple execute */


### PR DESCRIPTION
First try was in [this PR](https://github.com/reorg/pg_repack/pull/33). Now it passes regression tests on both PostgreSQL 9.3 and PostgreSQL 9.4.