### PR TITLE
Add a expected out file to run the repack regression test successfully.

### DIFF
--- a/regress/expected/repack_1.out
+++ b/regress/expected/repack_1.out
@@ -1,0 +1,389 @@
+SET client_min_messages = warning;
+--
+-- create table.
+--
+CREATE TABLE tbl_cluster (
+	col1 int,
+	"time" timestamp,
+	","")" text,
+	PRIMARY KEY (","")", col1) WITH (fillfactor = 75)
+) WITH (fillfactor = 70);
+CREATE INDEX ","") cluster" ON tbl_cluster ("time", length(","")"), ","")" text_pattern_ops) WITH (fillfactor = 75);
+ALTER TABLE tbl_cluster CLUSTER ON ","") cluster";
+CREATE TABLE tbl_only_pkey (
+	col1 int PRIMARY KEY,
+	","")" text
+);
+CREATE TABLE tbl_only_ckey (
+	col1 int,
+	col2 timestamp,
+	","")" text
+) WITH (fillfactor = 70);
+CREATE INDEX cidx_only_ckey ON tbl_only_ckey (col2, ","")");
+ALTER TABLE tbl_only_ckey CLUSTER ON cidx_only_ckey;
+CREATE TABLE tbl_gistkey (
+	id integer PRIMARY KEY,
+	c circle
+);
+CREATE INDEX cidx_circle ON tbl_gistkey USING gist (c);
+ALTER TABLE tbl_gistkey CLUSTER ON cidx_circle;
+CREATE TABLE tbl_with_dropped_column (
+	d1 text,
+	c1 text,
+	id integer PRIMARY KEY,
+	d2 text,
+	c2 text,
+	d3 text
+);
+ALTER INDEX tbl_with_dropped_column_pkey SET (fillfactor = 75);
+ALTER TABLE tbl_with_dropped_column CLUSTER ON tbl_with_dropped_column_pkey;
+CREATE INDEX idx_c1c2 ON tbl_with_dropped_column (c1, c2) WITH (fillfactor = 75);
+CREATE INDEX idx_c2c1 ON tbl_with_dropped_column (c2, c1);
+CREATE TABLE tbl_with_dropped_toast (
+	i integer,
+	j integer,
+	t text,
+	PRIMARY KEY (i, j)
+);
+ALTER TABLE tbl_with_dropped_toast CLUSTER ON tbl_with_dropped_toast_pkey;
+CREATE TABLE tbl_badindex (
+	id integer PRIMARY KEY,
+	n integer
+);
+CREATE TABLE tbl_idxopts (
+       i integer PRIMARY KEY,
+       t text
+);
+CREATE INDEX idxopts_t ON tbl_idxopts (t DESC NULLS LAST) WHERE (t != 'aaa');
+--
+-- insert data
+--
+INSERT INTO tbl_cluster VALUES(1, '2008-12-31 10:00:00', 'admin');
+INSERT INTO tbl_cluster VALUES(2, '2008-01-01 00:00:00', 'king');
+INSERT INTO tbl_cluster VALUES(3, '2008-03-04 12:00:00', 'joker');
+INSERT INTO tbl_cluster VALUES(4, '2008-03-05 15:00:00', 'queen');
+INSERT INTO tbl_cluster VALUES(5, '2008-01-01 00:30:00', sqrt(2::numeric(1000,999))::text || sqrt(3::numeric(1000,999))::text);
+INSERT INTO tbl_only_pkey VALUES(1, 'abc');
+INSERT INTO tbl_only_pkey VALUES(2, 'def');
+INSERT INTO tbl_only_ckey VALUES(1, '2008-01-01 00:00:00', 'abc');
+INSERT INTO tbl_only_ckey VALUES(2, '2008-02-01 00:00:00', 'def');
+INSERT INTO tbl_gistkey VALUES(1, '<(1,2),3>');
+INSERT INTO tbl_gistkey VALUES(2, '<(4,5),6>');
+INSERT INTO tbl_with_dropped_column VALUES('d1', 'c1', 2, 'd2', 'c2', 'd3');
+INSERT INTO tbl_with_dropped_column VALUES('d1', 'c1', 1, 'd2', 'c2', 'd3');
+ALTER TABLE tbl_with_dropped_column DROP COLUMN d1;
+ALTER TABLE tbl_with_dropped_column DROP COLUMN d2;
+ALTER TABLE tbl_with_dropped_column DROP COLUMN d3;
+ALTER TABLE tbl_with_dropped_column ADD COLUMN c3 text;
+CREATE VIEW view_for_dropped_column AS
+	SELECT * FROM tbl_with_dropped_column;
+INSERT INTO tbl_with_dropped_toast VALUES(1, 10, 'abc');
+INSERT INTO tbl_with_dropped_toast VALUES(2, 20, sqrt(2::numeric(1000,999))::text || sqrt(3::numeric(1000,999))::text);
+ALTER TABLE tbl_with_dropped_toast DROP COLUMN t;
+INSERT INTO tbl_badindex VALUES(1, 10);
+INSERT INTO tbl_badindex VALUES(2, 10);
+-- This will fail. Silence the message as it's different across PG versions.
+SET client_min_messages = fatal;
+CREATE UNIQUE INDEX CONCURRENTLY idx_badindex_n ON tbl_badindex (n);
+SET client_min_messages = warning;
+INSERT INTO tbl_idxopts VALUES (0, 'abc'), (1, 'aaa'), (2, NULL), (3, 'bbb');
+--
+-- before
+--
+SELECT * FROM tbl_with_dropped_column;
+ c1 | id | c2 | c3 
+----+----+----+----
+ c1 |  2 | c2 | 
+ c1 |  1 | c2 | 
+(2 rows)
+
+SELECT * FROM view_for_dropped_column;
+ c1 | id | c2 | c3 
+----+----+----+----
+ c1 |  2 | c2 | 
+ c1 |  1 | c2 | 
+(2 rows)
+
+SELECT * FROM tbl_with_dropped_toast;
+ i | j  
+---+----
+ 1 | 10
+ 2 | 20
+(2 rows)
+
+--
+-- do repack
+--
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster
+INFO: repacking table "tbl_cluster"
+\! pg_repack --dbname=contrib_regression --table=tbl_badindex
+INFO: repacking table "tbl_badindex"
+WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON tbl_badindex USING btree (n)
+\! pg_repack --dbname=contrib_regression
+INFO: repacking table "tbl_cluster"
+INFO: repacking table "tbl_only_pkey"
+INFO: repacking table "tbl_gistkey"
+INFO: repacking table "tbl_with_dropped_column"
+INFO: repacking table "tbl_with_dropped_toast"
+INFO: repacking table "tbl_badindex"
+WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON tbl_badindex USING btree (n)
+INFO: repacking table "tbl_idxopts"
+--
+-- after
+--
+\d tbl_cluster
+            Table "public.tbl_cluster"
+ Column |            Type             | Modifiers 
+--------+-----------------------------+-----------
+ col1   | integer                     | not null
+ time   | timestamp without time zone | 
+ ,")    | text                        | not null
+Indexes:
+    "tbl_cluster_pkey" PRIMARY KEY, btree (","")", col1) WITH (fillfactor=75)
+    ",") cluster" btree ("time", length(","")"), ","")" text_pattern_ops) WITH (fillfactor=75) CLUSTER
+
+\d tbl_gistkey
+  Table "public.tbl_gistkey"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ id     | integer | not null
+ c      | circle  | 
+Indexes:
+    "tbl_gistkey_pkey" PRIMARY KEY, btree (id)
+    "cidx_circle" gist (c) CLUSTER
+
+\d tbl_only_ckey
+           Table "public.tbl_only_ckey"
+ Column |            Type             | Modifiers 
+--------+-----------------------------+-----------
+ col1   | integer                     | 
+ col2   | timestamp without time zone | 
+ ,")    | text                        | 
+Indexes:
+    "cidx_only_ckey" btree (col2, ","")") CLUSTER
+
+\d tbl_only_pkey
+ Table "public.tbl_only_pkey"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ col1   | integer | not null
+ ,")    | text    | 
+Indexes:
+    "tbl_only_pkey_pkey" PRIMARY KEY, btree (col1)
+
+\d tbl_with_dropped_column
+Table "public.tbl_with_dropped_column"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ c1     | text    | 
+ id     | integer | not null
+ c2     | text    | 
+ c3     | text    | 
+Indexes:
+    "tbl_with_dropped_column_pkey" PRIMARY KEY, btree (id) WITH (fillfactor=75) CLUSTER
+    "idx_c1c2" btree (c1, c2) WITH (fillfactor=75)
+    "idx_c2c1" btree (c2, c1)
+
+\d tbl_with_dropped_toast
+Table "public.tbl_with_dropped_toast"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ i      | integer | not null
+ j      | integer | not null
+Indexes:
+    "tbl_with_dropped_toast_pkey" PRIMARY KEY, btree (i, j) CLUSTER
+
+\d tbl_idxopts
+  Table "public.tbl_idxopts"
+ Column |  Type   | Modifiers 
+--------+---------+-----------
+ i      | integer | not null
+ t      | text    | 
+Indexes:
+    "tbl_idxopts_pkey" PRIMARY KEY, btree (i)
+    "idxopts_t" btree (t DESC NULLS LAST) WHERE t <> 'aaa'::text
+
+SELECT col1, to_char("time", 'YYYY-MM-DD HH24:MI:SS'), ","")" FROM tbl_cluster;
+ col1 |       to_char       |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        ,")                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+------+---------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    2 | 2008-01-01 00:00:00 | king
+    5 | 2008-01-01 00:30:00 | 1.4142135623730950488016887242096980785696718753769480731766797379907324784621070388503875343276415727350138462309122970249248360558507372126441214970999358314132226659275055927557999505011527820605714701095599716059702745345968620147285174186408891986095523292304843087143214508397626036279952514079896872533965463318088296406206152583523950547457502877599617298355752203375318570113543746034084988471603868999706990048150305440277903164542478230684929369186215805784631115966687130130156185689872372352885092648612494977154218334204285686060146824720771435854874155657069677653720226485447015858801620758474922657226002085584466521458398893944370926591800311388246468157082630100594858704003186480342194897278290641045072636881313739855256117322040245091227700226941127573627280495738108967504018369868368450725799364729060762996941380475654823728997180326802474420629269124859052181004459842150591120249441341728531478105803603371077309182869314710171111683916581726889419758716582152128229518488471.732050807568877293527446341505872366942805253810380628055806979451933016908800037081146186757248575675626141415406703029969945094998952478811655512094373648528093231902305582067974820101084674923265015312343266903322886650672254668921837971227047131660367861588019049986537379859389467650347506576050756618348129606100947602187190325083145829523959832997789824508288714463832917347224163984587855397667958063818353666110843173780894378316102088305524901670023520711144288695990956365797087168498072899493296484283020786408603988738697537582317317831395992983007838702877053913369563312103707264019249106768231199288375641141422016742752102372994270831059898459475987664288897796147837958390228854852903576033852808064381972344661059689722872865264153822664698420021195484155278441181286534507035191650016689294415480846071277143999762926834629577438361895110127148638746976545982451788550975379013880664961911962222957110555242923723192197738262561631468842032853716682938649611917049738836395495938
+    3 | 2008-03-04 12:00:00 | joker
+    4 | 2008-03-05 15:00:00 | queen
+    1 | 2008-12-31 10:00:00 | admin
+(5 rows)
+
+SELECT * FROM tbl_only_ckey ORDER BY 1;
+ col1 |           col2           | ,") 
+------+--------------------------+-----
+    1 | Tue Jan 01 00:00:00 2008 | abc
+    2 | Fri Feb 01 00:00:00 2008 | def
+(2 rows)
+
+SELECT * FROM tbl_only_pkey ORDER BY 1;
+ col1 | ,") 
+------+-----
+    1 | abc
+    2 | def
+(2 rows)
+
+SELECT * FROM tbl_gistkey ORDER BY 1;
+ id |     c     
+----+-----------
+  1 | <(1,2),3>
+  2 | <(4,5),6>
+(2 rows)
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SELECT * FROM tbl_with_dropped_column;
+ c1 | id | c2 | c3 
+----+----+----+----
+ c1 |  1 | c2 | 
+ c1 |  2 | c2 | 
+(2 rows)
+
+SELECT * FROM view_for_dropped_column;
+ c1 | id | c2 | c3 
+----+----+----+----
+ c1 |  1 | c2 | 
+ c1 |  2 | c2 | 
+(2 rows)
+
+SELECT * FROM tbl_with_dropped_toast;
+ i | j  
+---+----
+ 1 | 10
+ 2 | 20
+(2 rows)
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SELECT * FROM tbl_with_dropped_column;
+ c1 | id | c2 | c3 
+----+----+----+----
+ c1 |  1 | c2 | 
+ c1 |  2 | c2 | 
+(2 rows)
+
+SELECT * FROM view_for_dropped_column;
+ c1 | id | c2 | c3 
+----+----+----+----
+ c1 |  1 | c2 | 
+ c1 |  2 | c2 | 
+(2 rows)
+
+SELECT * FROM tbl_with_dropped_toast;
+ i | j  
+---+----
+ 1 | 10
+ 2 | 20
+(2 rows)
+
+RESET enable_seqscan;
+RESET enable_indexscan;
+--
+-- check broken links or orphan toast relations
+--
+SELECT oid, relname
+  FROM pg_class
+ WHERE relkind = 't'
+   AND oid NOT IN (SELECT reltoastrelid FROM pg_class WHERE relkind = 'r');
+ oid | relname 
+-----+---------
+(0 rows)
+
+SELECT oid, relname
+  FROM pg_class
+ WHERE relkind = 'r'
+   AND reltoastrelid <> 0
+   AND reltoastrelid NOT IN (SELECT oid FROM pg_class WHERE relkind = 't');
+ oid | relname 
+-----+---------
+(0 rows)
+
+--
+-- NOT NULL UNIQUE
+--
+CREATE TABLE tbl_nn    (col1 int NOT NULL, col2 int NOT NULL);
+CREATE TABLE tbl_uk    (col1 int NOT NULL, col2 int         , UNIQUE(col1, col2));
+CREATE TABLE tbl_nn_uk (col1 int NOT NULL, col2 int NOT NULL, UNIQUE(col1, col2));
+CREATE TABLE tbl_pk_uk (col1 int NOT NULL, col2 int NOT NULL, PRIMARY KEY(col1, col2), UNIQUE(col2, col1));
+CREATE TABLE tbl_nn_puk (col1 int NOT NULL, col2 int NOT NULL);
+CREATE UNIQUE INDEX tbl_nn_puk_pcol1_idx ON tbl_nn_puk(col1) WHERE col1 < 10;
+\! pg_repack --dbname=contrib_regression --table=tbl_nn
+WARNING: relation "tbl_nn" must have a primary key or not-null unique keys
+-- => WARNING
+\! pg_repack --dbname=contrib_regression --table=tbl_uk
+WARNING: relation "tbl_uk" must have a primary key or not-null unique keys
+-- => WARNING
+\! pg_repack --dbname=contrib_regression --table=tbl_nn_uk
+INFO: repacking table "tbl_nn_uk"
+-- => OK
+\! pg_repack --dbname=contrib_regression --table=tbl_pk_uk
+INFO: repacking table "tbl_pk_uk"
+-- => OK
+\! pg_repack --dbname=contrib_regression --table=tbl_pk_uk --only-indexes
+INFO: repacking indexes of "tbl_pk_uk"
+INFO: repacking index "public"."tbl_pk_uk_col2_key"
+INFO: repacking index "public"."tbl_pk_uk_pkey"
+-- => OK
+\! pg_repack --dbname=contrib_regression --table=tbl_nn_puk
+WARNING: relation "tbl_nn_puk" must have a primary key or not-null unique keys
+-- => WARNING
+--
+-- Triggers handling
+--
+CREATE FUNCTION trgtest() RETURNS trigger AS
+$$BEGIN RETURN NEW; END$$
+LANGUAGE plpgsql;
+CREATE TABLE trg1 (id integer PRIMARY KEY);
+CREATE TRIGGER z_repack_triggeq BEFORE UPDATE ON trg1 FOR EACH ROW EXECUTE PROCEDURE trgtest();
+\! pg_repack --dbname=contrib_regression --table=trg1
+INFO: repacking table "trg1"
+CREATE TABLE trg2 (id integer PRIMARY KEY);
+CREATE TRIGGER z_repack_trigger BEFORE UPDATE ON trg2 FOR EACH ROW EXECUTE PROCEDURE trgtest();
+\! pg_repack --dbname=contrib_regression --table=trg2
+INFO: repacking table "trg2"
+WARNING: the table "trg2" already has a trigger called "z_repack_trigger"
+DETAIL: The trigger was probably installed during a previous attempt to run pg_repack on the table which was interrupted and for some reason failed to clean up the temporary objects.  Please drop the trigger or drop and recreate the pg_repack extension altogether to remove all the temporary objects left over.
+CREATE TABLE trg3 (id integer PRIMARY KEY);
+CREATE TRIGGER z_repack_trigges BEFORE UPDATE ON trg3 FOR EACH ROW EXECUTE PROCEDURE trgtest();
+\! pg_repack --dbname=contrib_regression --table=trg3
+INFO: repacking table "trg3"
+WARNING: trigger "z_repack_trigges" conflicting on table "trg3"
+DETAIL: The trigger "z_repack_trigger" must be the last of the BEFORE triggers to fire on the table (triggers fire in alphabetical order). Please rename the trigger so that it sorts before "z_repack_trigger": you can use "ALTER TRIGGER z_repack_trigges ON trg3 RENAME TO newname".
+CREATE TABLE trg4 (id integer PRIMARY KEY);
+CREATE TRIGGER zzzzzz AFTER UPDATE ON trg4 FOR EACH ROW EXECUTE PROCEDURE trgtest();
+\! pg_repack --dbname=contrib_regression --table=trg4
+INFO: repacking table "trg4"
+--
+-- Dry run
+--
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --dry-run
+INFO: Dry run enabled, not executing repack
+INFO: repacking table "tbl_cluster"
+-- Test --schema
+--
+CREATE SCHEMA test_schema1;
+CREATE TABLE test_schema1.tbl1 (id INTEGER PRIMARY KEY);
+CREATE TABLE test_schema1.tbl2 (id INTEGER PRIMARY KEY);
+CREATE SCHEMA test_schema2;
+CREATE TABLE test_schema2.tbl1 (id INTEGER PRIMARY KEY);
+CREATE TABLE test_schema2.tbl2 (id INTEGER PRIMARY KEY);
+-- => OK
+\! pg_repack --dbname=contrib_regression --schema=test_schema1
+INFO: repacking table "test_schema1.tbl1"
+INFO: repacking table "test_schema1.tbl2"
+-- => OK
+\! pg_repack --dbname=contrib_regression --schema=test_schema1 --schema=test_schema2
+INFO: repacking table "test_schema1.tbl1"
+INFO: repacking table "test_schema1.tbl2"
+INFO: repacking table "test_schema2.tbl1"
+INFO: repacking table "test_schema2.tbl2"
+-- => ERROR
+\! pg_repack --dbname=contrib_regression --schema=test_schema1 --table=tbl1
+ERROR: cannot repack specific table(s) in schema, use schema.table notation instead
+-- => ERROR
+\! pg_repack --dbname=contrib_regression --all --schema=test_schema1
+ERROR: cannot repack specific schema(s) in all databases


### PR DESCRIPTION
The 'repack' regression test fails on PostgreSQL 8.4 because the index name
assigned implicitely is different from 9.0 and after.

#### Probelm
```
$ cat regress/regression.diffs
*** /home/postgres/pg_repack/pg_repack/regress/expected/repack.out      2015-01-14 15:17:51.569064746 +0900
--- /home/postgres/pg_repack/pg_repack/regress/results/repack.out       2015-01-14 15:44:21.401063661 +0900
***************
*** 325,331 ****
  -- => OK
  \! pg_repack --dbname=contrib_regression --table=tbl_pk_uk --only-indexes
  INFO: repacking indexes of "tbl_pk_uk"
! INFO: repacking index "public"."tbl_pk_uk_col2_col1_key"
  INFO: repacking index "public"."tbl_pk_uk_pkey"
  -- => OK
  \! pg_repack --dbname=contrib_regression --table=tbl_nn_puk
--- 325,331 ----
  -- => OK
  \! pg_repack --dbname=contrib_regression --table=tbl_pk_uk --only-indexes
  INFO: repacking indexes of "tbl_pk_uk"
! INFO: repacking index "public"."tbl_pk_uk_col2_key"
  INFO: repacking index "public"."tbl_pk_uk_pkey"
  -- => OK
  \! pg_repack --dbname=contrib_regression --table=tbl_nn_puk

======================================================================
```

This diffs caused by the difference behaviors of PostgreSQL server to assign a index name.
In PostgreSQL 8.4,
```
postgres=# CREATE TABLE tbl_pk_uk (col1 int NOT NULL, col2 int NOT NULL, PRIMARY KEY(col1, col2), UNIQUE(col2, col1));
NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "tbl_pk_uk_pkey" for table "tbl_pk_uk"
NOTICE:  CREATE TABLE / UNIQUE will create implicit index "tbl_pk_uk_col2_key" for table "tbl_pk_uk"
CREATE TABLE
```
but in PostgreSQL 9.0 and after,
```
postgres=# CREATE TABLE tbl_pk_uk (col1 int NOT NULL, col2 int NOT NULL, PRIMARY KEY(col1, col2), UNIQUE(col2, col1));
NOTICE:  CREATE TABLE / PRIMARY KEY will create implicit index "tbl_pk_uk_pkey" for table "tbl_pk_uk"
NOTICE:  CREATE TABLE / UNIQUE will create implicit index "tbl_pk_uk_col2_col1_key" for table "tbl_pk_uk"
CREATE TABLE
```

#### Fix
I think there are two way to fix this.
One is to modify Makefile which check PostgreSQL server version and convert the index name in regress/expected/repack.out.
Another is to add one more expected file, regress/expected/repack_1.out which correspond the output against PostgreSQL 8.4.