### PR TITLE
Improve error message when repack against non-existing table.

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -341,7 +341,7 @@ main(int argc, char *argv[])
 		{
 			if (!repack_one_database(orderby, errbuf, sizeof(errbuf)))
 				ereport(ERROR,
-					(errcode(ERROR), errmsg("%s", errbuf)));
+					(errcode(ERROR), errmsg("pg_repack fails by PostgreSQL server error: %s", errbuf)));
 		}
 	}
 


### PR DESCRIPTION
Previously, pg_repack shows "ERROR: ERROR: relation foo does not exist" when specify non-existing table. 
Though the first ERROR is from pg_repack and the second ERROR is from PostgreSQL server, some users might think that pg_repack shows error level twice wrongly. So, this patch adds message explain it.