### PR TITLE
Change log level as noted in documentation.

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -1579,7 +1579,7 @@ static bool advisory_lock(PGconn *conn, const char *relid)
 		elog(ERROR, "%s",  PQerrorMessage(connection));
 	}
 	else if (strcmp(getstr(res, 0, 0), "t") != 0) {
-		elog(WARNING, "Another pg_repack command may be running on the table. Please try again later.");
+		elog(ERROR, "Another pg_repack command may be running on the table. Please try again later.");
 	}
 	else {
 		ret = true;


### PR DESCRIPTION
If there are two concurrent pg_repack commands are run on the same
table, the one starting later fails with error message:
Another pg_repack command may be running on the table. Please try again.
The document says this is shown as ERROR, but actualy is WARNING.