### PR TITLE
Include a new header file to build with PostgreSQL 9.5

### DIFF
--- a/lib/repack.c
+++ b/lib/repack.c
@@ -36,6 +36,11 @@
 #include "access/htup_details.h"
 #endif
 
+/* builtins.h was reorganized for 9.5, so now we need this header */
+#if PG_VERSION_NUM >= 90500
+#include "utils/ruleutils.h"
+#endif
+
 PG_MODULE_MAGIC;
 
 extern Datum PGUT_EXPORT repack_version(PG_FUNCTION_ARGS);


### PR DESCRIPTION
By commit 7b1c2a0f2066672b24f6257ec9b8d78a1754f494 in PostgreSQL,
builtins.h is splitted to a new header file ruleutils.h.
The usage of pg_get_indexdef_string in lib/repack.c is affected.