### PR TITLE
repack_apply(): Use default if count is negative

### DIFF
--- a/lib/repack.c
+++ b/lib/repack.c
@@ -237,7 +237,7 @@ repack_apply(PG_FUNCTION_ARGS)
 		bool			nulls[3];		/* id, pk, row */
 
 		/* peek tuple in log */
-		if (count == 0)
+		if (count <= 0)
 			values_peek[0] = Int32GetDatum(DEFAULT_PEEK_COUNT);
 		else
 			values_peek[0] = Int32GetDatum(Min(count - n, DEFAULT_PEEK_COUNT));


### PR DESCRIPTION
Per documentation, a negative value for count should result in using DEFAULT_PEEK_COUNT.