### PR TITLE
Make repack_drop() processing robust against deadlocks.

### DIFF
--- a/lib/repack.c
+++ b/lib/repack.c
@@ -968,8 +968,8 @@ repack_drop(PG_FUNCTION_ARGS)
 	 */
 	execute_with_format(
 		SPI_OK_UTILITY,
-		"LOCK TABLE %s IN ACCESS EXCLUSIVE MODE",
-		relname);
+		"LOCK TABLE %s.%s IN ACCESS EXCLUSIVE MODE",
+		nspname, relname);
 
 	/* drop log table: must be done before dropping the pk type,
 	 * since the log table is dependent on the pk type. (That's


### PR DESCRIPTION
Concurrent activity on the target table can cause deadlocks when
repack_drop() is doing its job, ie, dropping the temporary objects
created. It is highly likely to occur when pg_repack is interrupted
midway through its processing.

This fixes deadlock reported in issue #55 .