### PR TITLE
Fix regression test output

### DIFF
--- a/lib/repack.c
+++ b/lib/repack.c
@@ -16,6 +16,15 @@
 #include "catalog/dependency.h"
 #include "catalog/indexing.h"
 #include "catalog/namespace.h"
+
+/*
+ * utils/rel.h no longer includes pg_am.h as of 9.6, so need to include
+ * it explicitly.
+ */
+#if PG_VERSION_NUM >= 90600
+#include "catalog/pg_am.h"
+#endif
+
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_opclass.h"
 #include "catalog/pg_type.h"

--- a/regress/expected/repack.out
+++ b/regress/expected/repack.out
@@ -139,8 +139,8 @@ INFO: repacking table "tbl_idxopts"
  time   | timestamp without time zone | 
  ,")    | text                        | not null
 Indexes:
-    "tbl_cluster_pkey" PRIMARY KEY, btree (","")", col1) WITH (fillfactor=75)
-    ",") cluster" btree ("time", length(","")"), ","")" text_pattern_ops) WITH (fillfactor=75) CLUSTER
+    "tbl_cluster_pkey" PRIMARY KEY, btree (","")", col1) WITH (fillfactor='75')
+    ",") cluster" btree ("time", length(","")"), ","")" text_pattern_ops) WITH (fillfactor='75') CLUSTER
 
 \d tbl_gistkey
   Table "public.tbl_gistkey"
@@ -180,8 +180,8 @@ Table "public.tbl_with_dropped_column"
  c2     | text    | 
  c3     | text    | 
 Indexes:
-    "tbl_with_dropped_column_pkey" PRIMARY KEY, btree (id) WITH (fillfactor=75) CLUSTER
-    "idx_c1c2" btree (c1, c2) WITH (fillfactor=75)
+    "tbl_with_dropped_column_pkey" PRIMARY KEY, btree (id) WITH (fillfactor='75') CLUSTER
+    "idx_c1c2" btree (c1, c2) WITH (fillfactor='75')
     "idx_c2c1" btree (c2, c1)
 
 \d tbl_with_dropped_toast


### PR DESCRIPTION
Upstream changes (see commit c7e27bec in HEAD) now cause reloption values to be emitted with surrounding quotes. That breaks, for example, the outputs of \d commands in one of the tests.