### PR TITLE
grab exclusive lock before dropping table

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -1392,6 +1392,14 @@ repack_one_table(repack_table *table, const char *orderby)
 	elog(DEBUG2, "---- drop ----");
 
 	command("BEGIN ISOLATION LEVEL READ COMMITTED", 0, NULL);
+        if (!(lock_exclusive(connection, utoa(table->target_oid, buffer),
+                                                table->lock_table, FALSE)))
+        {
+                elog(WARNING, "lock_exclusive() failed in connection for %s",
+                         table->target_name);
+                goto cleanup;
+        }
+ 
 	params[1] = utoa(temp_obj_num, indexbuffer);
 	command("SELECT repack.repack_drop($1, $2)", 2, params);
 	command("COMMIT", 0, NULL);


### PR DESCRIPTION
Currently, if pg_repack is running for a table, and if a transaction starts right before the repack_drop section (#6) which updates the table, and does not commit, then pg_repack will hang, waiting for the transaction updating the table to commit. 

This hang can be reproduced by:
1. Run pg_repack in gdb for a table, and set a breakpoint at the elog() call in section 6 (drop) for repack_one_table().
2. When gdb stops at the break point, in a psql session, start a transaction and update the table.
3. In gdb, continue. This should hang (until the transaction in step 2 commits).

This change will call lock_exclusive() to grab an exclusive lock and kill other sessions before calling repack.repack_drop() in repack_one_table(). This will cause step 3 to cancel conflicting backends, and then continue to finish pg_repack.
