### PR TITLE
Don't wait for concurrent vacuums

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -66,6 +66,7 @@ const char *PROGRAM_VERSION = "unknown";
  *     https://github.com/reorg/pg_repack/issues/1
  *  d. open transactions/locks existing on other databases than the actual
  *     processing relation (except for locks on shared objects)
+ *  e. VACUUMs which are always executed outside transaction blocks.
  *
  * Note, there is some redundancy in how the filtering is done (e.g. excluding
  * based on pg_backend_pid() and application_name), but that shouldn't hurt

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -84,6 +84,8 @@ const char *PROGRAM_VERSION = "unknown";
 	"  AND l.pid NOT IN (pg_backend_pid(), $1) " \
 	"  AND (l.virtualxid, l.virtualtransaction) <> ('1/1', '-1/0') " \
 	"  AND (a.application_name IS NULL OR a.application_name <> $2)" \
+	"  AND a.query !~* E'^\\\\s*vacuum\\\\s+' " \
+	"  AND a.query !~ E'^autovacuum: ' " \
 	"  AND ((d.datname IS NULL OR d.datname = current_database()) OR l.database = 0)"
 
 #define SQL_XID_SNAPSHOT_90000 \
@@ -97,6 +99,8 @@ const char *PROGRAM_VERSION = "unknown";
 	"  AND l.pid NOT IN (pg_backend_pid(), $1) " \
 	"  AND (l.virtualxid, l.virtualtransaction) <> ('1/1', '-1/0') " \
 	"  AND (a.application_name IS NULL OR a.application_name <> $2)" \
+	"  AND a.query !~* E'^\\\\s*vacuum\\\\s+' " \
+	"  AND a.query !~ E'^autovacuum: ' " \
 	"  AND ((d.datname IS NULL OR d.datname = current_database()) OR l.database = 0)"
 
 /* application_name is not available before 9.0. The last clause of
@@ -111,6 +115,8 @@ const char *PROGRAM_VERSION = "unknown";
 	"    ON a.datid = d.oid " \
 	" WHERE l.locktype = 'virtualxid' AND l.pid NOT IN (pg_backend_pid(), $1)" \
 	" AND (l.virtualxid, l.virtualtransaction) <> ('1/1', '-1/0') " \
+	" AND a.query !~* E'^\\\\s*vacuum\\\\s+' " \
+	" AND a.query !~ E'^autovacuum: ' " \
 	" AND ((d.datname IS NULL OR d.datname = current_database()) OR l.database = 0)" \
 	" AND ($2::text IS NOT NULL)"
 


### PR DESCRIPTION
Our customers were faced following issue: pg_repack waits for concurrent vacuum to be complete before swapping tables. Vacuum could be slow on very large tables. Therefore it appears to be real problem.
Since VACUUMs are always outside transaction block, there is no risk that their sessions could see old data. This is why we propose to exclude vacuums (both autovacuums and manual vacuums) from list of vxids to wait.