### PR TITLE
new option 'include-extensions' (don't touch tables that belong to extensions)

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -625,6 +625,12 @@ repack_one_database(const char *orderby, char *errbuf, size_t errsize)
 	params[iparam++] = tablespace;
 	if (num_tables)
 	{
+		/*
+		 * Tables have been explicitly specified,
+		 * no need to hide tables of extensions
+		 */
+		include_extensions = true;
+
 		appendStringInfoString(&sql, "(");
 		for (cell = table_list.head; cell; cell = cell->next)
 		{

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -311,9 +311,15 @@ main(int argc, char *argv[])
 		else if (r_index.head && only_indexes)
 			ereport(ERROR, (errcode(EINVAL),
 				errmsg("cannot specify --index (-i) and --only-indexes (-x)")));
+		else if (r_index.head && exclude_extension_list.head)
+			ereport(ERROR, (errcode(EINVAL),
+				errmsg("cannot specify --index (-i) and --exclude-extension (-C)")));
 		else if (only_indexes && !table_list.head)
 			ereport(ERROR, (errcode(EINVAL),
 				errmsg("cannot repack all indexes of database, specify the table(s) via --table (-t)")));
+		else if (only_indexes && exclude_extension_list.head)
+			ereport(ERROR, (errcode(EINVAL),
+				errmsg("cannot specify --only-indexes (-x) and --exclude-extension (-C)")));
 		else if (alldb)
 			ereport(ERROR, (errcode(EINVAL),
 				errmsg("cannot repack specific index(es) in all databases")));
@@ -342,6 +348,11 @@ main(int argc, char *argv[])
 			ereport(ERROR,
 				(errcode(EINVAL),
 				 errmsg("cannot repack specific table(s) in schema, use schema.table notation instead")));
+
+		if (exclude_extension_list.head && table_list.head)
+			ereport(ERROR,
+				(errcode(EINVAL),
+				 errmsg("cannot specify --table (-t) and --exclude-extension (-C)")));
 
 		if (noorder)
 			orderby = "";

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -130,6 +130,7 @@ Options:
   -D, --no-kill-backend     don't kill other backends when timed out
   -Z, --no-analyze          don't analyze at end
   -k, --no-superuser-check  skip superuser checks in client
+  -C, --exclude-extension   don't repack tables which belong to specific extension
 
 Connection options:
   -d, --dbname=DBNAME       database to connect
@@ -222,6 +223,9 @@ Reorg Options
     Skip the superuser checks in the client.  This setting is useful for using
     pg_repack on platforms that support running it as non-superusers.
 
+``-C``, ``--exclude-extension``
+    Skip tables that belong to the specified extension(s). Some extensions
+    may heavily depend on such tables at planning time etc.
 
 Connection Options
 ^^^^^^^^^^^^^^^^^^

--- a/regress/expected/repack.out
+++ b/regress/expected/repack.out
@@ -403,3 +403,23 @@ ERROR: pg_repack failed with error: ERROR:  permission denied for schema repack
 LINE 1: select repack.version(), repack.version_sql()
                ^
 DROP ROLE IF EXISTS nosuper;
+--
+-- exclude extension check
+--
+CREATE SCHEMA exclude_extension_schema;
+CREATE TABLE exclude_extension_schema.tbl(val integer primary key);
+-- => ERROR
+\! pg_repack --dbname=contrib_regression --table=dummy_table --exclude-extension=dummy_extension
+ERROR: cannot specify --table (-t) and --exclude-extension (-C)
+-- => ERROR
+\! pg_repack --dbname=contrib_regression --table=dummy_table --exclude-extension=dummy_extension -x
+ERROR: cannot specify --only-indexes (-x) and --exclude-extension (-C)
+-- => ERROR
+\! pg_repack --dbname=contrib_regression --index=dummy_index --exclude-extension=dummy_extension
+ERROR: cannot specify --index (-i) and --exclude-extension (-C)
+-- => OK
+\! pg_repack --dbname=contrib_regression --schema=exclude_extension_schema --exclude-extension=dummy_extension
+INFO: repacking table "exclude_extension_schema.tbl"
+-- => OK
+\! pg_repack --dbname=contrib_regression --schema=exclude_extension_schema --exclude-extension=dummy_extension --exclude-extension=dummy_extension
+INFO: repacking table "exclude_extension_schema.tbl"

--- a/regress/sql/repack.sql
+++ b/regress/sql/repack.sql
@@ -245,3 +245,19 @@ CREATE ROLE nosuper WITH LOGIN;
 -- => ERROR
 \! pg_repack --dbname=contrib_regression --table=tbl_cluster --username=nosuper --no-superuser-check
 DROP ROLE IF EXISTS nosuper;
+
+--
+-- exclude extension check
+--
+CREATE SCHEMA exclude_extension_schema;
+CREATE TABLE exclude_extension_schema.tbl(val integer primary key);
+-- => ERROR
+\! pg_repack --dbname=contrib_regression --table=dummy_table --exclude-extension=dummy_extension
+-- => ERROR
+\! pg_repack --dbname=contrib_regression --table=dummy_table --exclude-extension=dummy_extension -x
+-- => ERROR
+\! pg_repack --dbname=contrib_regression --index=dummy_index --exclude-extension=dummy_extension
+-- => OK
+\! pg_repack --dbname=contrib_regression --schema=exclude_extension_schema --exclude-extension=dummy_extension
+-- => OK
+\! pg_repack --dbname=contrib_regression --schema=exclude_extension_schema --exclude-extension=dummy_extension --exclude-extension=dummy_extension


### PR DESCRIPTION
Hi guys,

I'm one of the developers of [pg_pathman](https://github.com/postgrespro/pg_pathman), a new partitioning tool for PostgreSQL.

Recently, one of our clients had trouble running pg_repack on a DB containing some tables partitioned by pg_pathman. In other words, pg_repack would hang _every time_ when trying to lock `pathman_config`, a table that we use to store partitioning configuration. As it turns out, when pg_repack opens a secondary connection and performs any query, our `post_parse_analyze_hook` comes into play and tries to read `pathman_config` (for planning purposes), which is impossible, hence the deadlock :(

This gave me an idea that it would be nice if we could make pg_repack forget about `pathman_config` and other tables that belong to their extensions. There might always be some code that heavily depends on such tables, so I've created a new option called `include-extensions` (which is set to false by default) to include them when it's really needed.

Hope this works out.
