### PR TITLE
Add 9.6 to list as a supported Postgres version.

### DIFF
--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -40,7 +40,7 @@ Requirements
 ------------
 
 PostgreSQL versions
-    PostgreSQL 8.3, 8.4, 9.0, 9.1, 9.2, 9.3, 9.4, 9.5
+    PostgreSQL 8.3, 8.4, 9.0, 9.1, 9.2, 9.3, 9.4, 9.5, 9.6
 
 Disks
     Performing a full-table repack requires free disk space about twice as

--- a/doc/pg_repack_jp.rst
+++ b/doc/pg_repack_jp.rst
@@ -62,7 +62,7 @@ pg_repackでは再編成する方法として次のものが選択できます�
   ------------
   
   PostgreSQL versions
-      PostgreSQL 8.3, 8.4, 9.0, 9.1, 9.2, 9.3, 9.4
+      PostgreSQL 8.3, 8.4, 9.0, 9.1, 9.2, 9.3, 9.4, 9.5, 9.6
   
   Disks
       Performing a full-table repack requires free disk space about twice as


### PR DESCRIPTION
Since 9.5 is not listed yet in pg_repack_jp.rst added 9.5 as well.

Regression test with Postgres 9.6 passed successfully.