### PR TITLE
Introduce --dont-kill-backend option.

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -154,8 +154,8 @@ const char *PROGRAM_VERSION = "unknown";
 
 #define COUNT_COMPETING_LOCKS \
 	"SELECT pid FROM pg_locks WHERE locktype = 'relation'" \
-	"AND granted = false AND relation = %u" \
-	"AND mode = 'AccessExclusiveLock' AND pid <> pg_backend_pid()"
+	" AND granted = false AND relation = %u" \
+	" AND mode = 'AccessExclusiveLock' AND pid <> pg_backend_pid()"
 
 /* Will be used as a unique prefix for advisory locks. */
 #define REPACK_LOCK_PREFIX_STR "16185446"

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -249,7 +249,7 @@ static int				wait_timeout = 60;	/* in seconds */
 static int				jobs = 0;	/* number of concurrent worker conns. */
 static bool				dryrun = false;
 static unsigned int		temp_obj_num = 0; /* temporary objects counter */
-static bool				dont_kill_backend = false; /* abandon when timed-out */
+static bool				no_kill_backend = false; /* abandon when timed-out */
 
 /* buffer should have at least 11 bytes */
 static char *
@@ -275,7 +275,7 @@ static pgut_option options[] =
 	{ 'i', 'T', "wait-timeout", &wait_timeout },
 	{ 'B', 'Z', "no-analyze", &analyze },
 	{ 'i', 'j', "jobs", &jobs },
-	{ 'b', 'D', "dont-kill-backend", &dont_kill_backend },
+	{ 'b', 'D', "no-kill-backend", &no_kill_backend },
 	{ 0 },
 };
 
@@ -1486,7 +1486,7 @@ kill_ddl(PGconn *conn, Oid relid, bool terminate)
 		/* Competing backend is exsits, but if we do not want to calcel/terminate
 		 * any backend, do nothing.
 		 */
-		if (dont_kill_backend)
+		if (no_kill_backend)
 		{
 			elog(WARNING, "%d unsafe queries remain but do not cancel them",
 				 n_tuples);
@@ -1681,7 +1681,7 @@ lock_exclusive(PGconn *conn, const char *relid, const char *lock_query, bool sta
 		duration = time(NULL) - start;
 		if (duration > wait_timeout)
 		{
-			if (dont_kill_backend)
+			if (no_kill_backend)
 			{
 				elog(WARNING, "timed out, do not cancel conflicting backends");
 				ret = false;
@@ -2101,6 +2101,6 @@ pgut_help(bool details)
 	printf("  -i, --index=INDEX         move only the specified index\n");
 	printf("  -x, --only-indexes        move only indexes of the specified table\n");
 	printf("  -T, --wait-timeout=SECS   timeout to cancel other backends on conflict\n");
-	printf("  -D, --dont-kill-backend   do not kill other backends when timed out\n");
+	printf("  -D, --no-kill-backend     don't kill other backends when timed out\n");
 	printf("  -Z, --no-analyze          don't analyze at end\n");
 }

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -127,7 +127,7 @@ Options:
   -i, --index=INDEX         move only the specified index
   -x, --only-indexes        move only indexes of the specified table
   -T, --wait-timeout=SECS   timeout to cancel other backends on conflict
-  -D, --dont-kill-backend   do not kill other backends when timed out
+  -D, --no-kill-backend     don't kill other backends when timed out
   -Z, --no-analyze          don't analyze at end
 
 Connection options:
@@ -202,13 +202,13 @@ Reorg Options
     pg_repack needs to take an exclusive lock at the end of the
     reorganization.  This setting controls how many seconds pg_repack will
     wait to acquire this lock. If the lock cannot be taken after this duration
-    and ``--dont-kill-backend`` option is not specified, pg_repack will forcibly
+    and ``--no-kill-backend`` option is not specified, pg_repack will forcibly
     cancel the conflicting queries. If you are using PostgreSQL version 8.4
     or newer, pg_repack will fall back to using pg_terminate_backend() to
     disconnect any remaining backends after twice this timeout has passed.
     The default is 60 seconds.
 
-``-D``, ``--dont-kill-backend``
+``-D``, ``--no-kill-backend``
     Skip to repack table if the lock cannot be taken for duration specified
     ``--wait-timeout``, instead of cancelling conflicting queries. The default
     is false.

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -127,6 +127,7 @@ Options:
   -i, --index=INDEX         move only the specified index
   -x, --only-indexes        move only indexes of the specified table
   -T, --wait-timeout=SECS   timeout to cancel other backends on conflict
+  -D, --dont-kill-backend   do not kill other backends when timed out
   -Z, --no-analyze          don't analyze at end
 
 Connection options:
@@ -200,11 +201,17 @@ Reorg Options
 ``-T SECS``, ``--wait-timeout=SECS``
     pg_repack needs to take an exclusive lock at the end of the
     reorganization.  This setting controls how many seconds pg_repack will
-    wait to acquire this lock. If the lock cannot be taken after this duration,
-    pg_repack will forcibly cancel the conflicting queries. If you are using
-    PostgreSQL version 8.4 or newer, pg_repack will fall back to using
-    pg_terminate_backend() to disconnect any remaining backends after
-    twice this timeout has passed. The default is 60 seconds.
+    wait to acquire this lock. If the lock cannot be taken after this duration
+    and ``--dont-kill-backend`` option is not specified, pg_repack will forcibly
+    cancel the conflicting queries. If you are using PostgreSQL version 8.4
+    or newer, pg_repack will fall back to using pg_terminate_backend() to
+    disconnect any remaining backends after twice this timeout has passed.
+    The default is 60 seconds.
+
+``-D``, ``--dont-kill-backend``
+    Skip to repack table if the lock cannot be taken for duration specified
+    ``--wait-timeout``, instead of cancelling conflicting queries. The default
+    is false.
 
 ``-Z``, ``--no-analyze``
     Disable ANALYZE after a full-table reorganization. If not specified, run

--- a/doc/pg_repack_jp.rst
+++ b/doc/pg_repack_jp.rst
@@ -206,6 +206,7 @@ pg_repackもしくはpg_reorgの古いバージョンからのアップグレー
     -i, --index=INDEX         move only the specified index
     -x, --only-indexes        move only indexes of the specified table
     -T, --wait-timeout=SECS   timeout to cancel other backends on conflict
+    -D, --no-kill-backend     don't kill other backends when timed out
     -Z, --no-analyze          don't analyze at end
   
   Connection options:
@@ -244,6 +245,7 @@ OPTIONには以下のものが指定できます。
   -i, --index=INDEX         指定したインデックスのみ再編成します
   -x, --only-indexes        指定したテーブルに付与されたインデックスだけを再編成します
   -T, --wait-timeout=SECS   ロック競合している他のトランザクションをキャンセルするまで待機する時間を指定します
+  -D, --no-kill-backend     タイムアウト時に他のバックエンドをキャンセルしません
   -Z, --no-analyze          再編成後にANALYZEを行いません
 
 接続オプション:
@@ -351,15 +353,22 @@ OPTIONには以下のものが指定できます。
 .. ``-T SECS``, ``--wait-timeout=SECS``
     pg_repack needs to take an exclusive lock at the end of the
     reorganization.  This setting controls how many seconds pg_repack will
-    wait to acquire this lock. If the lock cannot be taken after this duration,
-    pg_repack will forcibly cancel the conflicting queries. If you are using
-    PostgreSQL version 8.4 or newer, pg_repack will fall back to using
-    pg_terminate_backend() to disconnect any remaining backends after
-    twice this timeout has passed. The default is 60 seconds.
+    wait to acquire this lock. If the lock cannot be taken after this duration
+    and ``--no-kill-backend`` option is not specified, pg_repack will forcibly
+    cancel the conflicting queries. If you are using PostgreSQL version 8.4
+    or newer, pg_repack will fall back to using pg_terminate_backend() to
+    disconnect any remaining backends after twice this timeout has passed.
+    The default is 60 seconds.
 
 ``-T SECS``, ``--wait-timeout=SECS``
-    pg_repackは再編成の完了直前に排他ロックを利用します。このオプションは、このロック取得時に何秒間pg_repackが取得を待機するかを指定します。指定した時間経ってもロックが取得できない場合、pg_repackは競合するクエリを強制的にキャンセルさせます。PostgreSQL 8.4以上のバージョンを利用している場合、指定した時間の2倍以上経ってもロックが取得できない場合、pg_repackは競合するクエリを実行しているPostgreSQLバックエンドプロセスをpg_terminate_backend()関数により強制的に停止させます。このオプションのデフォルトは60秒です。
+    pg_repackは再編成の完了直前に排他ロックを利用します。このオプションは、このロック取得時に何秒間pg_repackが取得を待機するかを指定します。指定した時間経ってもロックが取得できないかつ、`no-kill-backend`オプションが指定されていない場合、pg_repackは競合するクエリを強制的にキャンセルさせます。PostgreSQL 8.4以上のバージョンを利用している場合、指定した時間の2倍以上経ってもロックが取得できない場合、pg_repackは競合するクエリを実行しているPostgreSQLバックエンドプロセスをpg_terminate_backend()関数により強制的に停止させます。このオプションのデフォルトは60秒です。
 
+..  ``-D``, ``--no-kill-backend``
+    Skip to repack table if the lock cannot be taken for duration specified
+    ``--wait-timeout``, instead of cancelling conflicting queries. The default
+    is false.
+``-D``, ``--no-kill-backend``
+    ``--wait-timeout``オプションで指定された時間が経過してもロックが取得できない場合、競合するクエリをキャンセルする代わりに対象テーブルの再編成をスキップします。
 
 .. ``-Z``, ``--no-analyze``
     Disable ANALYZE after a full-table reorganization. If not specified, run

--- a/regress/expected/repack.out
+++ b/regress/expected/repack.out
@@ -390,5 +390,5 @@ ERROR: cannot repack specific schema(s) in all databases
 --
 -- don't kill backend
 --
-\! pg_repack --dbname=contrib_regression --table=tbl_cluster --dont-kill-backend
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --no-kill-backend
 INFO: repacking table "tbl_cluster"

--- a/regress/expected/repack.out
+++ b/regress/expected/repack.out
@@ -387,3 +387,8 @@ ERROR: cannot repack specific table(s) in schema, use schema.table notation inst
 -- => ERROR
 \! pg_repack --dbname=contrib_regression --all --schema=test_schema1
 ERROR: cannot repack specific schema(s) in all databases
+--
+-- don't kill backend
+--
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --dont-kill-backend
+INFO: repacking table "tbl_cluster"

--- a/regress/sql/repack.sql
+++ b/regress/sql/repack.sql
@@ -230,3 +230,8 @@ CREATE TABLE test_schema2.tbl2 (id INTEGER PRIMARY KEY);
 \! pg_repack --dbname=contrib_regression --schema=test_schema1 --table=tbl1
 -- => ERROR
 \! pg_repack --dbname=contrib_regression --all --schema=test_schema1
+
+--
+-- don't kill backend
+--
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --dont-kill-backend

--- a/regress/sql/repack.sql
+++ b/regress/sql/repack.sql
@@ -234,4 +234,4 @@ CREATE TABLE test_schema2.tbl2 (id INTEGER PRIMARY KEY);
 --
 -- don't kill backend
 --
-\! pg_repack --dbname=contrib_regression --table=tbl_cluster --dont-kill-backend
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --no-kill-backend


### PR DESCRIPTION
pg_repack needs to take an exclusive lock at the end of the
reorganization. If the lock cannot be taken after duration
--wait-timeout option specified and this option is true,
pg_repack gives up to repack a target table instead of
cancelling conflicting backend. False by default.