### PR TITLE
Change format identifier of SPI_processed to uint64.

### DIFF
--- a/lib/repack.c
+++ b/lib/repack.c
@@ -1306,8 +1306,8 @@ repack_index_swap(PG_FUNCTION_ARGS)
 					 orig_idx_oid);
 	execute(SPI_OK_SELECT, str.data);
 	if (SPI_processed != 1)
-		elog(ERROR, "Could not find index 'index_%u', found %d matches",
-			 orig_idx_oid, SPI_processed);
+		elog(ERROR, "Could not find index 'index_%u', found %lu matches",
+			 orig_idx_oid, (uint64) SPI_processed);
 
 	tuptable = SPI_tuptable;
 	desc = tuptable->tupdesc;


### PR DESCRIPTION
Because commit 23a27b039d94ba359286694831eafe03cd970eef has extended the
type of SPI_processed from uint32 to uint64, pg_repack emit warning when
compiling with PostgreSQL 9.6 or later. To fix that, we cast it to uint64
and change format identifier from %d to %lu.

This change deals with issue #109 .