### PR TITLE
fix compilation with msvc

### DIFF
--- a/bin/pgut/pgut.h
+++ b/bin/pgut/pgut.h
@@ -24,6 +24,10 @@
 
 #define INFINITE_STR		"INFINITE"
 
+#ifdef _MSC_VER
+#define __attribute__(x)
+#endif
+
 typedef enum YesNo
 {
 	DEFAULT,

--- a/lib/pgut/pgut-spi.h
+++ b/lib/pgut/pgut-spi.h
@@ -12,6 +12,10 @@
 
 #include "executor/spi.h"
 
+#ifdef _MSC_VER
+#define __attribute__(x)
+#endif
+
 #if PG_VERSION_NUM < 80400
 
 extern int SPI_execute_with_args(const char *src, int nargs, Oid *argtypes,


### PR DESCRIPTION
__attribute__ macro is not defined in msvc and it is not essential to
the implementation. All it does  is tell the compiler that this function
is similar to printf, and  expects a printf-like format string
So for MSVC we define __attribute__ as a macro that do nothing