### PR TITLE
Introduce --no-superuser-check option.

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -277,7 +277,7 @@ static pgut_option options[] =
 	{ 'B', 'Z', "no-analyze", &analyze },
 	{ 'i', 'j', "jobs", &jobs },
 	{ 'b', 'D', "no-kill-backend", &no_kill_backend },
-  { 'b', 'k', "no-superuser-check", &no_superuser_check },
+	{ 'b', 'k', "no-superuser-check", &no_superuser_check },
 	{ 0 },
 };
 

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -244,6 +244,7 @@ static int				wait_timeout = 60;	/* in seconds */
 static int				jobs = 0;	/* number of concurrent worker conns. */
 static bool				dryrun = false;
 static unsigned int		temp_obj_num = 0; /* temporary objects counter */
+static bool				no_superuser_check = false;
 
 /* buffer should have at least 11 bytes */
 static char *
@@ -269,6 +270,7 @@ static pgut_option options[] =
 	{ 'i', 'T', "wait-timeout", &wait_timeout },
 	{ 'B', 'Z', "no-analyze", &analyze },
 	{ 'i', 'j', "jobs", &jobs },
+	{ 'b', 'k', "no-superuser-check", &no_superuser_check },
 	{ 0 },
 };
 
@@ -370,6 +372,9 @@ bool
 is_superuser(void)
 {
 	const char *val;
+
+	if (no_superuser_check)
+		return true;
 
 	if (!connection)
 		return false;
@@ -2064,4 +2069,5 @@ pgut_help(bool details)
 	printf("  -x, --only-indexes        move only indexes of the specified table\n");
 	printf("  -T, --wait-timeout=SECS   timeout to cancel other backends on conflict\n");
 	printf("  -Z, --no-analyze          don't analyze at end\n");
+	printf("  -k, --no-superuser-check  skip superuser checks in client\n");
 }

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -128,6 +128,7 @@ Options:
   -x, --only-indexes        move only indexes of the specified table
   -T, --wait-timeout=SECS   timeout to cancel other backends on conflict
   -Z, --no-analyze          don't analyze at end
+  -k, --no-superuser-check  skip superuser checks in client
 
 Connection options:
   -d, --dbname=DBNAME       database to connect
@@ -209,6 +210,10 @@ Reorg Options
 ``-Z``, ``--no-analyze``
     Disable ANALYZE after a full-table reorganization. If not specified, run
     ANALYZE after the reorganization.
+
+``-k``, ``--no-superuser-check``
+    Skip the superuser checks in the client.  This setting is useful for using
+    pg_repack on platforms that support running it as non-superusers.
 
 
 Connection Options

--- a/regress/expected/repack.out
+++ b/regress/expected/repack.out
@@ -386,3 +386,20 @@ ERROR: cannot repack specific schema(s) in all databases
 --
 \! pg_repack --dbname=contrib_regression --table=tbl_cluster --no-kill-backend
 INFO: repacking table "tbl_cluster"
+--
+-- no superuser check
+--
+DROP ROLE IF EXISTS nosuper;
+CREATE ROLE nosuper WITH LOGIN;
+-- => OK
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --no-superuser-check
+INFO: repacking table "tbl_cluster"
+-- => ERROR
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --username=nosuper
+ERROR: pg_repack failed with error: You must be a superuser to use pg_repack
+-- => ERROR
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --username=nosuper --no-superuser-check
+ERROR: pg_repack failed with error: ERROR:  permission denied for schema repack
+LINE 1: select repack.version(), repack.version_sql()
+               ^
+DROP ROLE IF EXISTS nosuper;

--- a/regress/sql/repack.sql
+++ b/regress/sql/repack.sql
@@ -232,3 +232,16 @@ CREATE TABLE test_schema2.tbl2 (id INTEGER PRIMARY KEY);
 -- don't kill backend
 --
 \! pg_repack --dbname=contrib_regression --table=tbl_cluster --no-kill-backend
+
+--
+-- no superuser check
+--
+DROP ROLE IF EXISTS nosuper;
+CREATE ROLE nosuper WITH LOGIN;
+-- => OK
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --no-superuser-check
+-- => ERROR
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --username=nosuper
+-- => ERROR
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --username=nosuper --no-superuser-check
+DROP ROLE IF EXISTS nosuper;


### PR DESCRIPTION
The current client checks for superuser before attempting to
execute pg_repack commands. In Amazon RDS, customers are given
access to a psuedo-superuser role called rds_superuser, but they
are not given access to superuser. However, rds_superusers will
otherwise have the ability to execute pg_repack commands in RDS.

This change introduces the --no-superuser-check option in the
client code so that users can disable the client-side superuser
checks.