### PR TITLE
Add "-X" option to avoid waiting for other transactions

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -239,6 +239,7 @@ static bool sqlstate_equals(PGresult *res, const char *state)
 
 static bool				analyze = true;
 static bool				alldb = false;
+static bool				no_paranoia = false;
 static bool				noorder = false;
 static SimpleStringList	parent_table_list = {NULL, NULL};
 static SimpleStringList	table_list = {NULL, NULL};
@@ -268,6 +269,7 @@ utoa(unsigned int value, char *buffer)
 static pgut_option options[] =
 {
 	{ 'b', 'a', "all", &alldb },
+	{ 'b', 'X', "disable-paranoia", &no_paranoia },
 	{ 'l', 't', "table", &table_list },
 	{ 'l', 'I', "parent-table", &parent_table_list },
 	{ 'l', 'c', "schema", &schema_list },
@@ -1440,6 +1442,15 @@ repack_one_table(repack_table *table, const char *orderby)
 		res = execute(SQL_XID_ALIVE, 1, params);
 		num = PQntuples(res);
 
+		/* display a warning if there are still one or more transactions
+		 * alive, but continue
+		 */
+		 if (no_paranoia)
+		 {
+			elog(NOTICE, "There are %d transactions waiting to finish, but skipping.", num);
+			break;
+		}
+
 		if (num > 0)
 		{
 			/* Wait for old transactions.
@@ -2224,4 +2235,5 @@ pgut_help(bool details)
 	printf("  -Z, --no-analyze          don't analyze at end\n");
 	printf("  -k, --no-superuser-check  skip superuser checks in client\n");
 	printf("  -C, --exclude-extension   don't repack tables which belong to specific extension\n");
+	printf("  -X, --disable-paranoia    don't wait for other existing transactions (use with care)\n");
 }


### PR DESCRIPTION
There was a conservative wait[1] for all existing transaction to
finish before repacking a table. This may not be desired on a busy
database on which you have long running transaction, which may block
pg_repack to do the job. This option will display a warning message,
but continues the process in such cases.

[1] http://lists.pgfoundry.org/pipermail/reorg-general/2015-October/000318.html