### PR TITLE
Avoid return from lock_exclusive() while in transaction ..

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -1771,6 +1771,7 @@ lock_exclusive(PGconn *conn, const char *relid, const char *lock_query, bool sta
 			{
 				elog(WARNING, "timed out, do not cancel conflicting backends");
 				ret = false;
+				pgut_rollback(conn);
 				break;
 			}
 			else


### PR DESCRIPTION
..causing "ERROR: DROP INDEX CONCURRENTLY cannot run inside a transaction block"
github#129