### PR TITLE
Fix a small memory leak in repack_one_database function.

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -852,6 +852,7 @@ cleanup:
 	CLEARPGRES(res);
 	disconnect();
 	termStringInfo(&sql);
+	free(params);
 	return ret;
 }
 


### PR DESCRIPTION
Total 3 issues were noticed by the coverity scan but other two issues were not problem actually.