### PR TITLE
Change to use only the characters that are printable ASCII.

### DIFF
--- a/regress/expected/repack.out
+++ b/regress/expected/repack.out
@@ -113,7 +113,12 @@ ALTER TABLE tbl_with_dropped_toast DROP COLUMN t;
 INSERT INTO tbl_badindex VALUES(1, 10);
 INSERT INTO tbl_badindex VALUES(2, 10);
 -- insert data that is always stored into the toast table if column type is extended.
-INSERT INTO tbl_with_mod_column_storage SELECT 1, array_to_string(ARRAY(SELECT chr(code) FROM generate_series(33,3000) code), '');
+SELECT setseed(0); INSERT INTO tbl_with_mod_column_storage SELECT 1, array_to_string(ARRAY(SELECT chr((random() * (127 - 32) + 32)::int) FROM generate_series(1, 3 * 1024) code), '');
+ setseed 
+---------
+ 
+(1 row)
+
 -- This will fail. Silence the message as it's different across PG versions.
 SET client_min_messages = fatal;
 CREATE UNIQUE INDEX CONCURRENTLY idx_badindex_n ON tbl_badindex (n);

--- a/regress/expected/repack_1.out
+++ b/regress/expected/repack_1.out
@@ -113,7 +113,12 @@ ALTER TABLE tbl_with_dropped_toast DROP COLUMN t;
 INSERT INTO tbl_badindex VALUES(1, 10);
 INSERT INTO tbl_badindex VALUES(2, 10);
 -- insert data that is always stored into the toast table if column type is extended.
-INSERT INTO tbl_with_mod_column_storage SELECT 1, array_to_string(ARRAY(SELECT chr(code) FROM generate_series(33,3000) code), '');
+SELECT setseed(0); INSERT INTO tbl_with_mod_column_storage SELECT 1, array_to_string(ARRAY(SELECT chr((random() * (127 - 32) + 32)::int) FROM generate_series(1, 3 * 1024) code), '');
+ setseed 
+---------
+ 
+(1 row)
+
 -- This will fail. Silence the message as it's different across PG versions.
 SET client_min_messages = fatal;
 CREATE UNIQUE INDEX CONCURRENTLY idx_badindex_n ON tbl_badindex (n);

--- a/regress/expected/repack_2.out
+++ b/regress/expected/repack_2.out
@@ -113,7 +113,12 @@ ALTER TABLE tbl_with_dropped_toast DROP COLUMN t;
 INSERT INTO tbl_badindex VALUES(1, 10);
 INSERT INTO tbl_badindex VALUES(2, 10);
 -- insert data that is always stored into the toast table if column type is extended.
-INSERT INTO tbl_with_mod_column_storage SELECT 1, array_to_string(ARRAY(SELECT chr(code) FROM generate_series(33,3000) code), '');
+SELECT setseed(0); INSERT INTO tbl_with_mod_column_storage SELECT 1, array_to_string(ARRAY(SELECT chr((random() * (127 - 32) + 32)::int) FROM generate_series(1, 3 * 1024) code), '');
+ setseed 
+---------
+ 
+(1 row)
+
 -- This will fail. Silence the message as it's different across PG versions.
 SET client_min_messages = fatal;
 CREATE UNIQUE INDEX CONCURRENTLY idx_badindex_n ON tbl_badindex (n);

--- a/regress/sql/repack.sql
+++ b/regress/sql/repack.sql
@@ -129,7 +129,7 @@ INSERT INTO tbl_badindex VALUES(1, 10);
 INSERT INTO tbl_badindex VALUES(2, 10);
 
 -- insert data that is always stored into the toast table if column type is extended.
-INSERT INTO tbl_with_mod_column_storage SELECT 1, array_to_string(ARRAY(SELECT chr(code) FROM generate_series(33,3000) code), '');
+SELECT setseed(0); INSERT INTO tbl_with_mod_column_storage SELECT 1, array_to_string(ARRAY(SELECT chr((random() * (127 - 32) + 32)::int) FROM generate_series(1, 3 * 1024) code), '');
 
 -- This will fail. Silence the message as it's different across PG versions.
 SET client_min_messages = fatal;


### PR DESCRIPTION
The regression test could fail on some environments such as where
the encoding is SQL_ASCII.

Fixed issue #130.