### PR TITLE
wrap tablespace name into quotes

### DIFF
--- a/lib/repack.c
+++ b/lib/repack.c
@@ -770,7 +770,7 @@ repack_indexdef(PG_FUNCTION_ARGS)
 
 	/* specify the new tablespace or the original one if any */
 	if (tablespace || stmt.tablespace)
-		appendStringInfo(&str, " TABLESPACE %s",
+		appendStringInfo(&str, " TABLESPACE \"%s\"",
 			(tablespace ? NameStr(*tablespace) : stmt.tablespace));
 
 	if (stmt.where)

--- a/regress/expected/tablespace.out
+++ b/regress/expected/tablespace.out
@@ -23,11 +23,11 @@ SELECT regexp_replace(
     '_[0-9]+', '_OID', 'g')
 FROM pg_index i join pg_class c ON c.oid = indexrelid
 WHERE indrelid = 'testts1'::regclass ORDER BY relname;
-                                              regexp_replace                                              
-----------------------------------------------------------------------------------------------------------
- CREATE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE pg_default WHERE (id > 0)
- CREATE UNIQUE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE pg_default
- CREATE INDEX index_OID ON repack.table_OID USING btree (id) WITH (fillfactor='80') TABLESPACE pg_default
+                                               regexp_replace                                               
+------------------------------------------------------------------------------------------------------------
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "pg_default" WHERE (id > 0)
+ CREATE UNIQUE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "pg_default"
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) WITH (fillfactor='80') TABLESPACE "pg_default"
 (3 rows)
 
 SELECT regexp_replace(
@@ -35,11 +35,11 @@ SELECT regexp_replace(
     '_[0-9]+', '_OID', 'g')
 FROM pg_index i join pg_class c ON c.oid = indexrelid
 WHERE indrelid = 'testts1'::regclass ORDER BY relname;
-                                          regexp_replace                                           
----------------------------------------------------------------------------------------------------
- CREATE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE foo WHERE (id > 0)
- CREATE UNIQUE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE foo
- CREATE INDEX index_OID ON repack.table_OID USING btree (id) WITH (fillfactor='80') TABLESPACE foo
+                                           regexp_replace                                            
+-----------------------------------------------------------------------------------------------------
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "foo" WHERE (id > 0)
+ CREATE UNIQUE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "foo"
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) WITH (fillfactor='80') TABLESPACE "foo"
 (3 rows)
 
 SELECT regexp_replace(
@@ -47,11 +47,11 @@ SELECT regexp_replace(
     '_[0-9]+', '_OID', 'g')
 FROM pg_index i join pg_class c ON c.oid = indexrelid
 WHERE indrelid = 'testts1'::regclass ORDER BY relname;
-                                                regexp_replace                                                
---------------------------------------------------------------------------------------------------------------
- CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) TABLESPACE pg_default WHERE (id > 0)
- CREATE UNIQUE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) TABLESPACE pg_default
- CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) WITH (fillfactor='80') TABLESPACE pg_default
+                                                 regexp_replace                                                 
+----------------------------------------------------------------------------------------------------------------
+ CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) TABLESPACE "pg_default" WHERE (id > 0)
+ CREATE UNIQUE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) TABLESPACE "pg_default"
+ CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) WITH (fillfactor='80') TABLESPACE "pg_default"
 (3 rows)
 
 SELECT regexp_replace(
@@ -59,11 +59,11 @@ SELECT regexp_replace(
     '_[0-9]+', '_OID', 'g')
 FROM pg_index i join pg_class c ON c.oid = indexrelid
 WHERE indrelid = 'testts1'::regclass ORDER BY relname;
-                                            regexp_replace                                             
--------------------------------------------------------------------------------------------------------
- CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) TABLESPACE foo WHERE (id > 0)
- CREATE UNIQUE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) TABLESPACE foo
- CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) WITH (fillfactor='80') TABLESPACE foo
+                                             regexp_replace                                              
+---------------------------------------------------------------------------------------------------------
+ CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) TABLESPACE "foo" WHERE (id > 0)
+ CREATE UNIQUE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) TABLESPACE "foo"
+ CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) WITH (fillfactor='80') TABLESPACE "foo"
 (3 rows)
 
 -- can move the tablespace from default

--- a/regress/expected/tablespace_1.out
+++ b/regress/expected/tablespace_1.out
@@ -35,11 +35,11 @@ SELECT regexp_replace(
     '_[0-9]+', '_OID', 'g')
 FROM pg_index i join pg_class c ON c.oid = indexrelid
 WHERE indrelid = 'testts1'::regclass ORDER BY relname;
-                                          regexp_replace                                           
----------------------------------------------------------------------------------------------------
- CREATE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE foo WHERE (id > 0)
- CREATE UNIQUE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE foo
- CREATE INDEX index_OID ON repack.table_OID USING btree (id) WITH (fillfactor='80') TABLESPACE foo
+                                           regexp_replace                                            
+-----------------------------------------------------------------------------------------------------
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "foo" WHERE (id > 0)
+ CREATE UNIQUE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "foo"
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) WITH (fillfactor='80') TABLESPACE "foo"
 (3 rows)
 
 SELECT regexp_replace(
@@ -59,11 +59,11 @@ SELECT regexp_replace(
     '_[0-9]+', '_OID', 'g')
 FROM pg_index i join pg_class c ON c.oid = indexrelid
 WHERE indrelid = 'testts1'::regclass ORDER BY relname;
-                                            regexp_replace                                             
--------------------------------------------------------------------------------------------------------
- CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) TABLESPACE foo WHERE (id > 0)
- CREATE UNIQUE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) TABLESPACE foo
- CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) WITH (fillfactor='80') TABLESPACE foo
+                                             regexp_replace                                              
+---------------------------------------------------------------------------------------------------------
+ CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) TABLESPACE "foo" WHERE (id > 0)
+ CREATE UNIQUE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) TABLESPACE "foo"
+ CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) WITH (fillfactor='80') TABLESPACE "foo"
 (3 rows)
 
 -- can move the tablespace from default

--- a/regress/expected/tablespace_2.out
+++ b/regress/expected/tablespace_2.out
@@ -23,11 +23,11 @@ SELECT regexp_replace(
     '_[0-9]+', '_OID', 'g')
 FROM pg_index i join pg_class c ON c.oid = indexrelid
 WHERE indrelid = 'testts1'::regclass ORDER BY relname;
-                                              regexp_replace                                              
-----------------------------------------------------------------------------------------------------------
- CREATE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE pg_default WHERE (id > 0)
- CREATE UNIQUE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE pg_default
- CREATE INDEX index_OID ON repack.table_OID USING btree (id) WITH (fillfactor='80') TABLESPACE pg_default
+                                               regexp_replace                                               
+------------------------------------------------------------------------------------------------------------
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "pg_default" WHERE (id > 0)
+ CREATE UNIQUE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "pg_default"
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) WITH (fillfactor='80') TABLESPACE "pg_default"
 (3 rows)
 
 SELECT regexp_replace(
@@ -35,11 +35,11 @@ SELECT regexp_replace(
     '_[0-9]+', '_OID', 'g')
 FROM pg_index i join pg_class c ON c.oid = indexrelid
 WHERE indrelid = 'testts1'::regclass ORDER BY relname;
-                                          regexp_replace                                           
----------------------------------------------------------------------------------------------------
- CREATE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE foo WHERE (id > 0)
- CREATE UNIQUE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE foo
- CREATE INDEX index_OID ON repack.table_OID USING btree (id) WITH (fillfactor='80') TABLESPACE foo
+                                           regexp_replace                                            
+-----------------------------------------------------------------------------------------------------
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "foo" WHERE (id > 0)
+ CREATE UNIQUE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "foo"
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) WITH (fillfactor='80') TABLESPACE "foo"
 (3 rows)
 
 SELECT regexp_replace(
@@ -47,11 +47,11 @@ SELECT regexp_replace(
     '_[0-9]+', '_OID', 'g')
 FROM pg_index i join pg_class c ON c.oid = indexrelid
 WHERE indrelid = 'testts1'::regclass ORDER BY relname;
-                                                   regexp_replace                                                    
----------------------------------------------------------------------------------------------------------------------
- CREATE INDEX CONCURRENTLY index_OID ON public.testts1 USING btree (id) TABLESPACE pg_default WHERE (id > 0)
- CREATE UNIQUE INDEX CONCURRENTLY index_OID ON public.testts1 USING btree (id) TABLESPACE pg_default
- CREATE INDEX CONCURRENTLY index_OID ON public.testts1 USING btree (id) WITH (fillfactor='80') TABLESPACE pg_default
+                                                    regexp_replace                                                     
+-----------------------------------------------------------------------------------------------------------------------
+ CREATE INDEX CONCURRENTLY index_OID ON public.testts1 USING btree (id) TABLESPACE "pg_default" WHERE (id > 0)
+ CREATE UNIQUE INDEX CONCURRENTLY index_OID ON public.testts1 USING btree (id) TABLESPACE "pg_default"
+ CREATE INDEX CONCURRENTLY index_OID ON public.testts1 USING btree (id) WITH (fillfactor='80') TABLESPACE "pg_default"
 (3 rows)
 
 SELECT regexp_replace(
@@ -59,11 +59,11 @@ SELECT regexp_replace(
     '_[0-9]+', '_OID', 'g')
 FROM pg_index i join pg_class c ON c.oid = indexrelid
 WHERE indrelid = 'testts1'::regclass ORDER BY relname;
-                                                regexp_replace                                                
---------------------------------------------------------------------------------------------------------------
- CREATE INDEX CONCURRENTLY index_OID ON public.testts1 USING btree (id) TABLESPACE foo WHERE (id > 0)
- CREATE UNIQUE INDEX CONCURRENTLY index_OID ON public.testts1 USING btree (id) TABLESPACE foo
- CREATE INDEX CONCURRENTLY index_OID ON public.testts1 USING btree (id) WITH (fillfactor='80') TABLESPACE foo
+                                                 regexp_replace                                                 
+----------------------------------------------------------------------------------------------------------------
+ CREATE INDEX CONCURRENTLY index_OID ON public.testts1 USING btree (id) TABLESPACE "foo" WHERE (id > 0)
+ CREATE UNIQUE INDEX CONCURRENTLY index_OID ON public.testts1 USING btree (id) TABLESPACE "foo"
+ CREATE INDEX CONCURRENTLY index_OID ON public.testts1 USING btree (id) WITH (fillfactor='80') TABLESPACE "foo"
 (3 rows)
 
 -- can move the tablespace from default

--- a/regress/expected/tablespace_3.out
+++ b/regress/expected/tablespace_3.out
@@ -35,11 +35,11 @@ SELECT regexp_replace(
     '_[0-9]+', '_OID', 'g')
 FROM pg_index i join pg_class c ON c.oid = indexrelid
 WHERE indrelid = 'testts1'::regclass ORDER BY relname;
-                                         regexp_replace                                          
--------------------------------------------------------------------------------------------------
- CREATE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE foo WHERE (id > 0)
- CREATE UNIQUE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE foo
- CREATE INDEX index_OID ON repack.table_OID USING btree (id) WITH (fillfactor=80) TABLESPACE foo
+                                          regexp_replace                                           
+---------------------------------------------------------------------------------------------------
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "foo" WHERE (id > 0)
+ CREATE UNIQUE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "foo"
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) WITH (fillfactor=80) TABLESPACE "foo"
 (3 rows)
 
 SELECT regexp_replace(
@@ -59,11 +59,11 @@ SELECT regexp_replace(
     '_[0-9]+', '_OID', 'g')
 FROM pg_index i join pg_class c ON c.oid = indexrelid
 WHERE indrelid = 'testts1'::regclass ORDER BY relname;
-                                           regexp_replace                                            
------------------------------------------------------------------------------------------------------
- CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) TABLESPACE foo WHERE (id > 0)
- CREATE UNIQUE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) TABLESPACE foo
- CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) WITH (fillfactor=80) TABLESPACE foo
+                                            regexp_replace                                             
+-------------------------------------------------------------------------------------------------------
+ CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) TABLESPACE "foo" WHERE (id > 0)
+ CREATE UNIQUE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) TABLESPACE "foo"
+ CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) WITH (fillfactor=80) TABLESPACE "foo"
 (3 rows)
 
 -- can move the tablespace from default


### PR DESCRIPTION
When a tablespace has some special characters (like hyphen "-"), the generated SQL produces syntax error. To avoid it, tablespace name should be wrapped into double quotes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/reorg/pg_repack/177)
<!-- Reviewable:end -->
