### PR TITLE
Remove duplicate password prompt

### DIFF
--- a/bin/pgut/pgut.c
+++ b/bin/pgut/pgut.c
@@ -452,8 +452,15 @@ prompt_for_password(void)
 	}
 #else
 	buf = (char *)malloc(BUFSIZE);
-	if (buf != NULL)
-		simple_prompt("Password: ", buf, BUFSIZE, false);
+	if (already_passwd_done) {
+		memcpy(buf, passwdbuf, sizeof(char)*BUFSIZE);
+	} else {
+		if (buf != NULL)
+			simple_prompt("Password: ", buf, BUFSIZE, false);
+		already_passwd_done = true;
+		passwdbuf = (char *)malloc(BUFSIZE);
+		memcpy(passwdbuf, buf, sizeof(char)*BUFSIZE);
+	}
 #endif
 
 	if (buf == NULL)

--- a/bin/pgut/pgut.c
+++ b/bin/pgut/pgut.c
@@ -435,10 +435,21 @@ static char *
 prompt_for_password(void)
 {
 	char *buf;
+	static char *passwdbuf;
+	static bool already_passwd_done = false;
+
 #define BUFSIZE 100
 
 #if PG_VERSION_NUM < 100000
-	buf = simple_prompt("Password: ", BUFSIZE, false);
+	if (already_passwd_done) {
+		buf = (char *)malloc(BUFSIZE);
+		memcpy(buf, passwdbuf, sizeof(char)*BUFSIZE);
+	} else {
+		buf = simple_prompt("Password: ", BUFSIZE, false);
+		already_passwd_done = true;
+		passwdbuf = (char *)malloc(BUFSIZE);
+		memcpy(passwdbuf, buf, sizeof(char)*BUFSIZE);
+	}
 #else
 	buf = (char *)malloc(BUFSIZE);
 	if (buf != NULL)


### PR DESCRIPTION
Currently pg_repack requires some duplicate password prompt although I expect only one password prompt.

For example if table space is not specified, password prompt required twice. If table space is specified, password prompt required four times.
So this PR removes some duplicate password prompt.

- Before

```
$ pg_repack --no-superuser-check --table=testtbl --dbname=test --host=postgres-test.c5x5yhkaqvsm.us-west-2.rds.amazonaws.com --port=5432 --username=hayshogo --password --elevel=DEBUG --tablespace=testspace
DEBUG: No workers to disconnect.
Password: 
Password: 
DEBUG: No workers to disconnect.
Password: 
Password: 
INFO: repacking table "testtbl"
DEBUG: ---- repack_one_table ----
DEBUG: target_name       : testtbl
DEBUG: target_oid        : 24628
:
:
```

- After

```
$ pg_repack --no-superuser-check --table=testtbl --dbname=test --host=postgres-test.c5x5yhkaqvsm.us-west-2.rds.amazonaws.com --port=5432 --username=hayshogo --password --elevel=DEBUG --tablespace=testspace
DEBUG: No workers to disconnect.
Password: 
DEBUG: No workers to disconnect.
INFO: repacking table "testtbl"
DEBUG: ---- repack_one_table ----
DEBUG: target_name       : testtbl
DEBUG: target_oid        : 24628
```