### PR TITLE
Documentation : the wait timeout flag

### DIFF
--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -197,8 +197,8 @@ Reorg Options
     with the ``--table`` or ``--parent-table`` options.
 
 ``-T SECS``, ``--wait-timeout=SECS``
-    pg_repack needs to take an exclusive lock at the end of the
-    reorganization.  This setting controls how many seconds pg_repack will
+    pg_repack needs to take an exclusive lock at the beginning and at the end of 
+    the reorganization.  This setting controls how many seconds pg_repack will
     wait to acquire this lock. If the lock cannot be taken after this duration
     and ``--no-kill-backend`` option is not specified, pg_repack will forcibly
     cancel the conflicting queries. If you are using PostgreSQL version 8.4


### PR DESCRIPTION
I ran into a situation where the timeout was reached at the very beginning of the operations (because I use -D and there was an autovacuum running), and I was confused by the documentation.
The details section of the documentation states clearly that the ACCESS EXCLUSIVE locks are needed at the beginning and at the end of the repack, but I propose to make the `--wait-timeout`flag documentation a little clearer on this.

Thank you for this amazing tool btw !