### PR TITLE
Fix pg_repack build for PostgreSQL 11 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ dist: trusty
 sudo: required
 
 env:
-  - PGVER=10
+  - PGVER=11
     PGTESTING=1
+  - PGVER=10
   - PGVER=9.6
   - PGVER=9.5
   - PGVER=9.4

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -1176,7 +1176,7 @@ repack_one_table(repack_table *table, const char *orderby)
 	if (!advisory_lock(connection, buffer))
 		goto cleanup;
 
-	if (!(lock_exclusive(connection, buffer, table->lock_table, TRUE)))
+	if (!(lock_exclusive(connection, buffer, table->lock_table, true)))
 	{
 		if (no_kill_backend)
 			elog(INFO, "Skipping repack %s due to timeout", table->target_name);
@@ -1483,7 +1483,7 @@ repack_one_table(repack_table *table, const char *orderby)
 	/* Bump our existing AccessShare lock to AccessExclusive */
 
 	if (!(lock_exclusive(conn2, utoa(table->target_oid, buffer),
-						 table->lock_table, FALSE)))
+						 table->lock_table, false)))
 	{
 		elog(WARNING, "lock_exclusive() failed in conn2 for %s",
 			 table->target_name);
@@ -1502,7 +1502,7 @@ repack_one_table(repack_table *table, const char *orderby)
 
 	command("BEGIN ISOLATION LEVEL READ COMMITTED", 0, NULL);
 	if (!(lock_exclusive(connection, utoa(table->target_oid, buffer),
-						 table->lock_table, FALSE)))
+						 table->lock_table, false)))
 	{
 		elog(WARNING, "lock_exclusive() failed in connection for %s",
 			 table->target_name);
@@ -2045,7 +2045,7 @@ repack_table_indexes(PGresult *index_details)
 	resetStringInfo(&sql);
 	appendStringInfo(&sql, "LOCK TABLE %s IN ACCESS EXCLUSIVE MODE",
 					 table_name);
-	if (!(lock_exclusive(connection, params[1], sql.data, TRUE)))
+	if (!(lock_exclusive(connection, params[1], sql.data, true)))
 	{
 		elog(WARNING, "lock_exclusive() failed in connection for %s",
 			 table_name);

--- a/lib/repack.c
+++ b/lib/repack.c
@@ -704,7 +704,11 @@ repack_get_order_by(PG_FUNCTION_ARGS)
 				if (indexRel == NULL)
 					indexRel = index_open(index, NoLock);
 
+#if PG_VERSION_NUM >= 110000
 				opcintype = TupleDescAttr(RelationGetDescr(indexRel), nattr)->atttypid;
+#else
+				opcintype = RelationGetDescr(indexRel)->attrs[nattr]->atttypid;
+#endif
 			}
 
 			oprid = get_opfamily_member(opfamily, opcintype, opcintype, strategy);

--- a/lib/repack.c
+++ b/lib/repack.c
@@ -24,8 +24,14 @@
 #if PG_VERSION_NUM >= 90600
 #include "catalog/pg_am.h"
 #endif
-
+/*
+ * catalog/pg_foo_fn.h headers was merged back into pg_foo.h headers
+ */
+#if PG_VERSION_NUM >= 110000
+#include "catalog/pg_inherits.h"
+#else
 #include "catalog/pg_inherits_fn.h"
+#endif
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_opclass.h"
 #include "catalog/pg_type.h"

--- a/lib/repack.c
+++ b/lib/repack.c
@@ -225,7 +225,7 @@ repack_apply(PG_FUNCTION_ARGS)
 	uint32			n, i;
 	Oid				argtypes_peek[1] = { INT4OID };
 	Datum			values_peek[1];
-	bool			nulls_peek[1] = { 0 };
+	const char			nulls_peek[1] = { 0 };
 	StringInfoData		sql_pop;
 
 	initStringInfo(&sql_pop);
@@ -287,21 +287,21 @@ repack_apply(PG_FUNCTION_ARGS)
 				/* INSERT */
 				if (plan_insert == NULL)
 					plan_insert = repack_prepare(sql_insert, 1, &argtypes[2]);
-				execute_plan(SPI_OK_INSERT, plan_insert, &values[2], &nulls[2]);
+				execute_plan(SPI_OK_INSERT, plan_insert, &values[2], (nulls[2] ? "n" : " "));
 			}
 			else if (nulls[2])
 			{
 				/* DELETE */
 				if (plan_delete == NULL)
 					plan_delete = repack_prepare(sql_delete, 1, &argtypes[1]);
-				execute_plan(SPI_OK_DELETE, plan_delete, &values[1], &nulls[1]);
+				execute_plan(SPI_OK_DELETE, plan_delete, &values[1], (nulls[1] ? "n" : " "));
 			}
 			else
 			{
 				/* UPDATE */
 				if (plan_update == NULL)
 					plan_update = repack_prepare(sql_update, 2, &argtypes[1]);
-				execute_plan(SPI_OK_UPDATE, plan_update, &values[1], &nulls[1]);
+				execute_plan(SPI_OK_UPDATE, plan_update, &values[1], (nulls[1] ? "n" : " "));
 			}
 
 			/* Add the primary key ID of each row from the log
@@ -704,7 +704,7 @@ repack_get_order_by(PG_FUNCTION_ARGS)
 				if (indexRel == NULL)
 					indexRel = index_open(index, NoLock);
 
-				opcintype = RelationGetDescr(indexRel)->attrs[nattr]->atttypid;
+				opcintype = TupleDescAttr(RelationGetDescr(indexRel), nattr)->atttypid;
 			}
 
 			oprid = get_opfamily_member(opfamily, opcintype, opcintype, strategy);


### PR DESCRIPTION
Hi
I will try fix build for recent releases. Build seems broken due [9a95a77d9d5d3003d2d67121f2731b6e5fc37336](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=9a95a77d9d5d3003d2d67121f2731b6e5fc37336) and [6337865f36da34e9c89aaa292f976bde6df0b065](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=6337865f36da34e9c89aaa292f976bde6df0b065) commits in PostgreSQL code: uppercase FALSE and TRUE constants was removed and was allowed using standart stdbool.h for boolean types.

Fix issue #181

Thank you