### PR TITLE
Fix a parallel processing fails for indexes with operators from public schema.

### DIFF
--- a/bin/pgut/pgut-fe.c
+++ b/bin/pgut/pgut-fe.c
@@ -100,7 +100,7 @@ setup_workers(int num_workers)
 			}
 
 			/* Hardcode a search path to avoid injections into public or pg_temp */
-			pgut_command(conn, "SET search_path TO pg_catalog, pg_temp", 0, NULL);
+			pgut_command(conn, "SET search_path TO pg_catalog, pg_temp, public", 0, NULL);
 
             /* Make sure each worker connection can work in non-blocking
              * mode.

--- a/bin/pgut/pgut.c
+++ b/bin/pgut/pgut.c
@@ -523,7 +523,7 @@ pgut_connect(const char *info, YesNo prompt, int elevel)
 			free(passwd);
 
 			/* Hardcode a search path to avoid injections into public or pg_temp */
-			pgut_command(conn, "SET search_path TO pg_catalog, pg_temp", 0, NULL);
+			pgut_command(conn, "SET search_path TO pg_catalog, pg_temp, public", 0, NULL);
 
 			return conn;
 		}


### PR DESCRIPTION
A pull request that solves a side effect by a patch that addresses the vulnerability CVE-2018-1058.
=============

What is the problem?
-------------
When pg_repack is executed in parallel, it does not find the operator class installed in the public schema.
```
Issue items.
https://github.com/reorg/pg_repack/issues/187
https://github.com/reorg/pg_repack/issues/185
```
cause of problem
-------------
The PGConn used when there are two or more walkers sets the search_path to pg_catalog, pg_temp at the setup_workers function.

```
https://github.com/reorg/pg_repack/blob/9bfd94562e77ead67dfcc1713916f862a4a8ee4d/bin/pgut/pgut-fe.c#L46

pgut_command(conn, "SET search_path TO pg_catalog, pg_temp", 0, NULL);
```

Therefore, the PGConn used in parallel processing cannot find the operator class installed in the public schema.

Why is there no problem if it is non-parallel processing?
-------------
pg_repack uses the command function to send a query to PostgreSQL when there is only one worker.
(If two or more walkers, use the PQsendQuery function instead of the command function.)
```

https://github.com/reorg/pg_repack/blob/9bfd94562e77ead67dfcc1713916f862a4a8ee4d/bin/pg_repack.c#L896
		...
		if (num_workers <= 1) {
			command(index_jobs[i].create_index, 0, NULL);
		}
		...
		else if (i < num_workers) {
			if (!(PQsendQuery(workers.conns[i], index_jobs[i].create_index)))
		}
		...

```
The PGconn used by the command function resets the search_path to pg_catalog, pg_temp, public using the function of preliminary_checks.
```

https://github.com/reorg/pg_repack/blob/9bfd94562e77ead67dfcc1713916f862a4a8ee4d/bin/pg_repack.c#L549

static bool
preliminary_checks(char *errbuf, size_t errsize){
	command("SET search_path = pg_catalog, pg_temp, public", 0, NULL);
	...
}

```
Therefore, when there is only one worker, no problem occurs.

How to fix the problem
-------------
Set the search_path in the pgut_connect and setup_workers functions to pg_catalog, pg_temp, public in the existing pg_catalog, pg_temp.



Please review to this bug fix patch.
Regards.
Moon.