### PR TITLE
Don't suppress CREATE UNIQUE INDEX output

### DIFF
--- a/regress/expected/repack-setup.out
+++ b/regress/expected/repack-setup.out
@@ -104,10 +104,9 @@ SELECT setseed(0); INSERT INTO tbl_with_mod_column_storage SELECT 1, array_to_st
  
 (1 row)
 
--- This will fail. Silence the message as it's different across PG versions.
-SET client_min_messages = fatal;
+\set VERBOSITY terse
 CREATE UNIQUE INDEX CONCURRENTLY idx_badindex_n ON tbl_badindex (n);
-SET client_min_messages = warning;
+ERROR:  could not create unique index "idx_badindex_n"
 INSERT INTO tbl_idxopts VALUES (0, 'abc'), (1, 'aaa'), (2, NULL), (3, 'bbb');
 -- Insert no-ordered data
 INSERT INTO tbl_order SELECT generate_series(100, 51, -1);

--- a/regress/sql/repack-setup.sql
+++ b/regress/sql/repack-setup.sql
@@ -122,10 +122,8 @@ INSERT INTO tbl_badindex VALUES(2, 10);
 -- insert data that is always stored into the toast table if column type is extended.
 SELECT setseed(0); INSERT INTO tbl_with_mod_column_storage SELECT 1, array_to_string(ARRAY(SELECT chr((random() * (127 - 32) + 32)::int) FROM generate_series(1, 3 * 1024) code), '');
 
--- This will fail. Silence the message as it's different across PG versions.
-SET client_min_messages = fatal;
+\set VERBOSITY terse
 CREATE UNIQUE INDEX CONCURRENTLY idx_badindex_n ON tbl_badindex (n);
-SET client_min_messages = warning;
 
 INSERT INTO tbl_idxopts VALUES (0, 'abc'), (1, 'aaa'), (2, NULL), (3, 'bbb');
 


### PR DESCRIPTION
Latest PostgreSQL minors (11.2 and friends) inhibit setting
client_min_messages greater than 'error'. The output from CREATE UNIQUE
INDEX has previously been ignored because it differs across versions,
but at least 9.4+ behave the same, so just proceed normally.

Context: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=7b08b4a8a