### PR TITLE
Escape table names for --only-indexes

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -2132,7 +2132,7 @@ repack_all_indexes(char *errbuf, size_t errsize)
 	else if (table_list.head || parent_table_list.head)
 	{
 		appendStringInfoString(&sql,
-			"SELECT repack.oid2text(i.oid), idx.indexrelid, idx.indisvalid, idx.indrelid, $1::text, n.nspname"
+			"SELECT repack.oid2text(i.oid), idx.indexrelid, idx.indisvalid, idx.indrelid, repack.oid2text(idx.indrelid), n.nspname"
 			" FROM pg_index idx JOIN pg_class i ON i.oid = idx.indexrelid"
 			" JOIN pg_namespace n ON n.oid = i.relnamespace"
 			" WHERE idx.indrelid = $1::regclass ORDER BY indisvalid DESC, i.relname, n.nspname");


### PR DESCRIPTION
Currently, the `--only-indexes` option doesn't escape table names given in the command line and causes the following error:

```
LOG: (query) LOCK TABLE table-name IN ACCESS EXCLUSIVE MODE
ERROR:  syntax error at or near "-"
LINE 1: LOCK TABLE table-name IN ACCESS ...
                                            ^
ERROR: query failed: ERROR:  current transaction is aborted, commands ignored until end of transaction block
```

Example:
```
pg_repack -h SERVER -U USER -d DATABASE --echo --table='table-name' --only-indexes
```

Note: There's a workaround, you can add double quotes to the table name, however, this is something very easy to miss and cause the database become in an invalid state with a lot of indexes uncomplete rebuilt.

This PR change the SQL query used in `bin/pg_repack` and fix the issue.