### PR TITLE
Support for postgresql 13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Global excludes across all subdirectories
 *.o
 *.so
+*.bc
 regress/regression.diffs
 regress/regression.out
 regress/results/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ dist: xenial
 sudo: required
 
 env:
+  - PGVER=13
+    PGTESTING=1
   - PGVER=12
   - PGVER=11
   - PGVER=10

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: required
 
 env:
   - PGVER=13
-    PGTESTING=1
   - PGVER=12
   - PGVER=11
   - PGVER=10

--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
    "name": "pg_repack",
    "abstract": "PostgreSQL module for data reorganization",
    "description": "Reorganize tables in PostgreSQL databases with minimal locks",
-   "version": "1.4.5",
+   "version": "1.4.6",
    "maintainer": [
        "Beena Emerson <memissemerson@gmail.com>",
        "Josh Kupershmidt <schmiddy@gmail.com>",
@@ -15,7 +15,7 @@
    "provides": {
       "pg_repack": {
          "file": "lib/pg_repack.sql",
-         "version": "1.4.5",
+         "version": "1.4.6",
          "abstract": "Reorganize tables in PostgreSQL databases with minimal locks"
       }
    },

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -40,7 +40,7 @@ Requirements
 ------------
 
 PostgreSQL versions
-    PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11, 12
+    PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10, 11, 12, 13
 
 Disks
     Performing a full-table repack requires free disk space about twice as

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -466,6 +466,10 @@ Creating indexes concurrently comes with a few caveats, please see `the document
 Releases
 --------
 
+* pg_repack 1.4.6
+
+  * Added support for PostgreSQL 13
+
 * pg_repack 1.4.5
 
   * Added support for PostgreSQL 12

--- a/lib/repack.c
+++ b/lib/repack.c
@@ -19,7 +19,6 @@
 
 /*
  * heap_open/heap_close was moved to table_open/table_close in 12.0
- * table.h has macros mapping the old names to the new ones
  */
 #if PG_VERSION_NUM >= 120000
 #include "access/table.h"
@@ -1169,7 +1168,11 @@ swap_heap_or_index_files(Oid r1, Oid r2)
 	CatalogIndexState indstate;
 
 	/* We need writable copies of both pg_class tuples. */
+#if PG_VERSION_NUM >= 120000
+	relRelation = table_open(RelationRelationId, RowExclusiveLock);
+#else
 	relRelation = heap_open(RelationRelationId, RowExclusiveLock);
+#endif
 
 	reltup1 = SearchSysCacheCopy(RELOID,
 								 ObjectIdGetDatum(r1),
@@ -1332,7 +1335,11 @@ swap_heap_or_index_files(Oid r1, Oid r2)
 	heap_freetuple(reltup1);
 	heap_freetuple(reltup2);
 
+#if PG_VERSION_NUM >= 120000
+	table_close(relRelation, RowExclusiveLock);
+#else
 	heap_close(relRelation, RowExclusiveLock);
+#endif
 }
 
 /**


### PR DESCRIPTION
Hello.
It is me again and my new patch for the upcoming PostgreSQL release v13.

- compatibility macroses heap_open and head_close [was removed](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=f25968c49697db673f6cd2a07b3f7626779f1827) in postgresql.

This seems to be the only incompatible change so far.