### PR TITLE
Remove all references to pgfoundry domain

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,6 @@ pg_repack -- Reorganize tables in PostgreSQL databases with minimal locks
 - Download: https://pgxn.org/dist/pg_repack/
 - Development: https://github.com/reorg/pg_repack
 - Bug Report: https://github.com/reorg/pg_repack/issues
-- Mailing List: http://pgfoundry.org/mailman/listinfo/reorg-general
 
 |travis|
 
@@ -49,4 +48,4 @@ drop-in replacement: you are advised to check the documentation__ before
 upgrading from previous versions.
 
 .. __: pg_repack_
-.. _pg_reorg: http://reorg.projects.pgfoundry.org/
+.. _pg_reorg: https://github.com/reorg

--- a/SPECS/pg_repack84.spec
+++ b/SPECS/pg_repack84.spec
@@ -2,22 +2,22 @@
 # Copyright(C) 2009-2010 NIPPON TELEGRAPH AND TELEPHONE CORPORATION
 %define sname	pg_repack
 
-Summary:	Reorganize tables in PostgreSQL databases without any locks. 
+Summary:	Reorganize tables in PostgreSQL databases without any locks.
 Name:		%{sname}
 Version:	1.1.5
 Release:	1%{?dist}
 License:	BSD
 Group:		Applications/Databases
 Source0:	%{sname}-%{version}.tar.gz
-URL:		http://pgfoundry.org/projects/%{sname}/
+URL:		https://reorg.github.io/pg_repack/
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-%(%{__id_u} -n)
 
 BuildRequires:	postgresql-devel, postgresql
 Requires:	postgresql, postgresql-libs
 
-%description 	
-pg_repack can re-organize tables on a postgres database without any locks so that 
-you can retrieve or update rows in tables being reorganized. 
+%description
+pg_repack can re-organize tables on a postgres database without any locks so that
+you can retrieve or update rows in tables being reorganized.
 The module is developed to be a better alternative of CLUSTER and VACUUM FULL.
 
 %prep
@@ -39,15 +39,15 @@ install -m 755 lib/pg_repack.so			%{buildroot}%{_libdir}/pgsql/pg_repack.so
 install -m 644 lib/pg_repack.sql			%{buildroot}%{_datadir}/pgsql/contrib/pg_repack.sql
 install -m 644 lib/uninstall_pg_repack.sql	%{buildroot}%{_datadir}/pgsql/contrib/uninstall_pg_repack.sql
 
-%define pg_sharedir 
+%define pg_sharedir
 
 %files
 %defattr(755,root,root,755)
 %{_bindir}/pg_repack
 %{_libdir}/pgsql/pg_repack.so
 %defattr(644,root,root,755)
-%{_datadir}/pgsql/contrib/pg_repack.sql 
-%{_datadir}/pgsql/contrib/uninstall_pg_repack.sql 
+%{_datadir}/pgsql/contrib/pg_repack.sql
+%{_datadir}/pgsql/contrib/uninstall_pg_repack.sql
 
 %clean
 rm -rf %{buildroot}

--- a/SPECS/pg_repack90.spec
+++ b/SPECS/pg_repack90.spec
@@ -7,22 +7,22 @@
 %define _libdir  %{_pgdir}/lib
 %define _datadir %{_pgdir}/share
 
-Summary:	Reorganize tables in PostgreSQL databases without any locks. 
+Summary:	Reorganize tables in PostgreSQL databases without any locks.
 Name:		%{sname}
 Version:	1.1.5
 Release:	1%{?dist}
 License:	BSD
 Group:		Applications/Databases
 Source0:	%{sname}-%{version}.tar.gz
-URL:		http://pgfoundry.org/projects/%{sname}/
+URL:		https://reorg.github.io/pg_repack/
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-%(%{__id_u} -n)
 
 BuildRequires:	postgresql90-devel, postgresql90
 Requires:	postgresql90, postgresql90-libs
 
-%description 	
-pg_repack can re-organize tables on a postgres database without any locks so that 
-you can retrieve or update rows in tables being reorganized. 
+%description
+pg_repack can re-organize tables on a postgres database without any locks so that
+you can retrieve or update rows in tables being reorganized.
 The module is developed to be a better alternative of CLUSTER and VACUUM FULL.
 
 %prep
@@ -44,15 +44,15 @@ install -m 755 lib/pg_repack.so			%{buildroot}%{_libdir}/pg_repack.so
 install -m 644 lib/pg_repack.sql			%{buildroot}%{_datadir}/contrib/pg_repack.sql
 install -m 644 lib/uninstall_pg_repack.sql	%{buildroot}%{_datadir}/contrib/uninstall_pg_repack.sql
 
-%define pg_sharedir 
+%define pg_sharedir
 
 %files
 %defattr(755,root,root,755)
 %{_bindir}/pg_repack
 %{_libdir}/pg_repack.so
 %defattr(644,root,root,755)
-%{_datadir}/contrib/pg_repack.sql 
-%{_datadir}/contrib/uninstall_pg_repack.sql 
+%{_datadir}/contrib/pg_repack.sql
+%{_datadir}/contrib/uninstall_pg_repack.sql
 
 %clean
 rm -rf %{buildroot}

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -11,7 +11,7 @@
  */
 
 const char *PROGRAM_URL		= "http://reorg.github.com/pg_repack";
-const char *PROGRAM_EMAIL	= "reorg-general@lists.pgfoundry.org";
+const char *PROGRAM_EMAIL	= 0;
 
 #ifdef REPACK_VERSION
 /* macro trick to stringify a macro expansion */

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -33,7 +33,7 @@ NOTICE:
 .. _VACUUM FULL: VACUUM_
 .. _VACUUM: http://www.postgresql.org/docs/current/static/sql-vacuum.html
 .. _project page: https://github.com/reorg/pg_repack
-.. _pg_reorg: http://reorg.projects.pgfoundry.org/
+.. _pg_reorg: https://github.com/reorg
 
 
 Requirements
@@ -64,8 +64,8 @@ the package; use::
 
 Check the `pgxn install documentation`__ for the options available.
 
-.. _PGXN Client: http://pgxnclient.projects.pgfoundry.org/
-.. __: http://pgxnclient.projects.pgfoundry.org/usage.html#pgxn-install
+.. _PGXN Client: https://pgxn.github.io/pgxnclient/
+.. __: https://pgxn.github.io/pgxnclient/usage.html#pgxn-install
 
 
 Installation

--- a/doc/pg_repack_jp.rst
+++ b/doc/pg_repack_jp.rst
@@ -55,7 +55,7 @@ pg_repackでは再編成する方法として次のものが選択できます�
 .. _VACUUM FULL: VACUUM_
 .. _VACUUM: http://www.postgresql.jp/document/current/html/sql-vacuum.html
 .. _project page: https://github.com/reorg/pg_repack
-.. _pg_reorg: http://reorg.projects.pgfoundry.org/
+.. _pg_reorg: https://github.com/reorg
 
 
 .. Requirements
@@ -95,8 +95,8 @@ PostgreSQL バージョン
   
   Check the `pgxn install documentation`__ for the options available.
   
-  .. _PGXN Client: http://pgxnclient.projects.pgfoundry.org/
-  .. __: http://pgxnclient.projects.pgfoundry.org/usage.html#pgxn-install
+  .. _PGXN Client: https://pgxn.github.io/pgxnclient/
+  .. __: https://pgxn.github.io/pgxnclient/usage.html#pgxn-install
 
 
 ダウンロード
@@ -113,8 +113,8 @@ pg_repackは、PGXNのWebサイトから `ダウンロード`__ できます。
 
 利用可能なオプションについては `pgxn install コマンドのドキュメント`__ を参照してください。
 
-.. _PGXN Client: http://pgxnclient.projects.pgfoundry.org/
-.. __: http://pgxnclient.projects.pgfoundry.org/usage.html#pgxn-install
+.. _PGXN Client: https://pgxn.github.io/pgxnclient/
+.. __: https://pgxn.github.io/pgxnclient/usage.html#pgxn-install
 
 
 

--- a/doc/release.rst
+++ b/doc/release.rst
@@ -27,7 +27,7 @@ with the right privileges: contact Daniele Varrazzo to obtain them.
   the path, e.g. ``PATH=$(pg_config --bindir):$PATH``; check the ``install``
   log to see where ``pg_repack`` executable was installed).
 
-  .. __: http://pgxnclient.projects.pgfoundry.org/
+  .. __: https://pgxn.github.io/pgxnclient/
 
 - Push the code changes on github::
 
@@ -60,5 +60,4 @@ with the right privileges: contact Daniele Varrazzo to obtain them.
 
 - Check the page http://reorg.github.io/pg_repack/ is right.
 
-- Announce the package on reorg-general@pgfoundry.org and
-  pgsql-announce@postgresql.org.
+- Announce the package on pgsql-announce@postgresql.org.

--- a/regress/travis_prepare.sh
+++ b/regress/travis_prepare.sh
@@ -39,7 +39,10 @@ else
     sudo apt-get update
     sudo apt-get install -y "libpq5=${PGVER}*" "libpq-dev=${PGVER}*"
     sudo apt-mark hold libpq5
-    sudo apt-get install -y postgresql-server-dev-$PGVER postgresql-$PGVER
+    # NOTE: This command started failing in Postgres 9.6 in Travis CI
+    # due to the post-install script failing to start Postgres.
+    # See https://github.com/reorg/pg_repack/pull/237
+    sudo apt-get install -y postgresql-server-dev-$PGVER postgresql-$PGVER || [ "${PGVER}" = "9.6" ]
 
     # ensure PostgreSQL is running on 5432 port with proper auth
     sudo sed -i \


### PR DESCRIPTION
This started 404ing in 2019, and at the time of writing, appears to link to a bodybuilding forum at a glance
(Pro Gains)

Related to #204 - I strongly doubt the mailing list will get restored on that site, and I couldn't find anything else mirroring it after a quick search for `"reorg-general" mailing list`