### PR TITLE
Adds reference to docker image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,7 @@ pg_repack -- Reorganize tables in PostgreSQL databases with minimal locks
 - Download: https://pgxn.org/dist/pg_repack/
 - Development: https://github.com/reorg/pg_repack
 - Bug Report: https://github.com/reorg/pg_repack/issues
+- Docker: https://hub.docker.com/repository/docker/hartmutcouk/pg-repack-docker
 
 |travis|
 


### PR DESCRIPTION
Hi, 
I'm maintaining a docker image for pg_repack - in the past I've had used it with a cron job for a scheduled 'cleanup' of tables with a high update frequency.
PR is as simple as referencing the docker image on the main README file - please advise if you'd rather have it someplace else?!?