### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@
 dist: xenial
 sudo: required
 
+arch:
+  - AMD64
+  - ppc64le
+
 env:
   - PGVER=13
   - PGVER=12


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.