### PR TITLE
new option "switch-threshold"

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -285,7 +285,7 @@ static pgut_option options[] =
 	{ 'b', 'D', "no-kill-backend", &no_kill_backend },
 	{ 'b', 'k', "no-superuser-check", &no_superuser_check },
 	{ 'l', 'C', "exclude-extension", &exclude_extension_list },
-	{ 'i', 't', "switch-threshold", &switch_threshold },
+	{ 'i', 'r', "switch-threshold", &switch_threshold },
 	{ 0 },
 };
 
@@ -2238,5 +2238,5 @@ pgut_help(bool details)
 	printf("  -Z, --no-analyze          don't analyze at end\n");
 	printf("  -k, --no-superuser-check  skip superuser checks in client\n");
 	printf("  -C, --exclude-extension   don't repack tables which belong to specific extension\n");
-	printf("  -t, --switch-threshold    switch tables when that many tuples are left to catchup\n");
+	printf("  -r, --switch-threshold    switch tables when that many tuples are left to catchup\n");
 }

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -123,6 +123,7 @@ Options:
   -Z, --no-analyze          don't analyze at end
   -k, --no-superuser-check  skip superuser checks in client
   -C, --exclude-extension   don't repack tables which belong to specific extension
+  -r, --switch-threshold    switch tables when that many tuples are left to catchup
 
 Connection options:
   -d, --dbname=DBNAME       database to connect
@@ -222,6 +223,10 @@ Reorg Options
 ``-C``, ``--exclude-extension``
     Skip tables that belong to the specified extension(s). Some extensions
     may heavily depend on such tables at planning time etc.
+
+``-r``, ``--switch-threshold``
+    Switch tables when that many tuples are left in log table.
+    This setting can be used to avoid the inability to catchup with write-heavy tables.
 
 Connection Options
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Hello!
Recently, when running pg_repack on really busy table, we were unable to catchup due to MIN_TUPLES_BEFORE_SWITCH been less than the size of average insert, populating the table.
So I would like to propose the patch, which should remedy such situations by parameterizing the switch threshold value instead of using macro. New options is "-r | --switch-threshold"

Thank you for a great tool.