### PR TITLE
Support for postgresql 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,15 @@ dist: xenial
 sudo: required
 
 env:
+  - PGVER=14
+    PGTESTING=1
   - PGVER=13
   - PGVER=12
   - PGVER=11
   - PGVER=10
   # Disabled because packages broken at least on xenial
   # https://www.postgresql.org/message-id/CA%2Bmi_8a1oEnCzkt0CvqysgY4MQ6jEefjmS%3Dq_K-AvOx%3DF7m2%2BQ%40mail.gmail.com
-  # - PGVER=9.6
+  - PGVER=9.6
   - PGVER=9.5
   - PGVER=9.4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # Travis CI configuration file for psycopg2
 
-dist: xenial
+dist: focal
 sudo: required
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: required
 
 env:
   - PGVER=14
-    PGTESTING=1
   - PGVER=13
   - PGVER=12
   - PGVER=11

--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
    "name": "pg_repack",
    "abstract": "PostgreSQL module for data reorganization",
    "description": "Reorganize tables in PostgreSQL databases with minimal locks",
-   "version": "1.4.6",
+   "version": "1.4.7",
    "maintainer": [
        "Beena Emerson <memissemerson@gmail.com>",
        "Josh Kupershmidt <schmiddy@gmail.com>",
@@ -15,7 +15,7 @@
    "provides": {
       "pg_repack": {
          "file": "lib/pg_repack.sql",
-         "version": "1.4.6",
+         "version": "1.4.7",
          "abstract": "Reorganize tables in PostgreSQL databases with minimal locks"
       }
    },

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -212,6 +212,7 @@ typedef struct repack_table
 static bool is_superuser(void);
 static void check_tablespace(void);
 static bool preliminary_checks(char *errbuf, size_t errsize);
+static bool is_requested_relation_exists(char *errbuf, size_t errsize);
 static void repack_all_databases(const char *order_by);
 static bool repack_one_database(const char *order_by, char *errbuf, size_t errsize);
 static void repack_one_table(repack_table *table, const char *order_by);
@@ -559,6 +560,109 @@ cleanup:
 }
 
 /*
+ * Check the presence of tables specified by --parent-table and --table
+ * otherwise format user-friendly message
+ */
+static bool
+is_requested_relation_exists(char *errbuf, size_t errsize){
+	bool			ret = false;
+	PGresult		*res = NULL;
+	const char	    **params = NULL;
+	int				iparam = 0;
+	StringInfoData	sql;
+	int				num_relations;
+	SimpleStringListCell   *cell;
+
+	num_relations = simple_string_list_size(parent_table_list) +
+					simple_string_list_size(table_list);
+
+	/* nothing was implicitly requested, so nothing to do here */
+	if (num_relations == 0)
+		return true;
+
+	params = pgut_malloc(num_relations * sizeof(char *));
+	initStringInfo(&sql);
+	appendStringInfoString(&sql, "SELECT r FROM (VALUES ");
+
+	for (cell = table_list.head; cell; cell = cell->next)
+	{
+		appendStringInfo(&sql, "($%d)", iparam + 1);
+		params[iparam++] = cell->val;
+		if (iparam < num_relations)
+			appendStringInfoChar(&sql, ',');
+	}
+	for (cell = parent_table_list.head; cell; cell = cell->next)
+	{
+		appendStringInfo(&sql, "($%d)", iparam + 1);
+		params[iparam++] = cell->val;
+		if (iparam < num_relations)
+			appendStringInfoChar(&sql, ',');
+	}
+	appendStringInfoString(&sql,
+		") AS given_t(r)"
+		" WHERE NOT EXISTS("
+		"  SELECT FROM repack.tables WHERE relid=to_regclass(given_t.r) )"
+	);
+
+	/* double check the parameters array is sane */
+	if (iparam != num_relations)
+	{
+		if (errbuf)
+			snprintf(errbuf, errsize,
+				"internal error: bad parameters count: %i instead of %i",
+				 iparam, num_relations);
+		goto cleanup;
+	}
+
+	res = execute_elevel(sql.data, iparam, params, DEBUG2);
+	if (PQresultStatus(res) == PGRES_TUPLES_OK)
+	{
+		int 	num;
+
+		num = PQntuples(res);
+
+		if (num != 0)
+		{
+			int i;
+			StringInfoData	rel_names;
+			initStringInfo(&rel_names);
+
+			for (i = 0; i < num; i++)
+			{
+				appendStringInfo(&rel_names, "\"%s\"", getstr(res, i, 0));
+				if ((i + 1) != num)
+					appendStringInfoString(&rel_names, ", ");
+			}
+
+			if (errbuf)
+			{
+				if (num > 1)
+					snprintf(errbuf, errsize,
+							"relations do not exist: %s", rel_names.data);
+				else
+					snprintf(errbuf, errsize,
+							"relation %s does not exist", rel_names.data);
+			}
+			termStringInfo(&rel_names);
+		}
+		else
+			ret = true;
+	}
+	else
+	{
+		if (errbuf)
+			snprintf(errbuf, errsize, "%s", PQerrorMessage(connection));
+	}
+	CLEARPGRES(res);
+
+cleanup:
+	CLEARPGRES(res);
+	termStringInfo(&sql);
+	free(params);
+	return ret;
+}
+
+/*
  * Call repack_one_database for each database.
  */
 static void
@@ -655,6 +759,9 @@ repack_one_database(const char *orderby, char *errbuf, size_t errsize)
 		setup_workers(jobs);
 
 	if (!preliminary_checks(errbuf, errsize))
+		goto cleanup;
+
+	if (!is_requested_relation_exists(errbuf, errsize))
 		goto cleanup;
 
 	/* acquire target tables */
@@ -2113,6 +2220,9 @@ repack_all_indexes(char *errbuf, size_t errsize)
 	assert(r_index.head || table_list.head || parent_table_list.head);
 
 	if (!preliminary_checks(errbuf, errsize))
+		goto cleanup;
+
+	if (!is_requested_relation_exists(errbuf, errsize))
 		goto cleanup;
 
 	if (r_index.head)

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -580,6 +580,10 @@ is_requested_relation_exists(char *errbuf, size_t errsize){
 	if (num_relations == 0)
 		return true;
 
+	/* has no suitable to_regclass(text) */
+	if (PQserverVersion(connection)<90600)
+		return true;
+
 	params = pgut_malloc(num_relations * sizeof(char *));
 	initStringInfo(&sql);
 	appendStringInfoString(&sql, "SELECT r FROM (VALUES ");
@@ -641,7 +645,7 @@ is_requested_relation_exists(char *errbuf, size_t errsize){
 							"relations do not exist: %s", rel_names.data);
 				else
 					snprintf(errbuf, errsize,
-							"relation %s does not exist", rel_names.data);
+							"ERROR:  relation %s does not exist", rel_names.data);
 			}
 			termStringInfo(&rel_names);
 		}

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -75,7 +75,7 @@ const char *PROGRAM_VERSION = "unknown";
  * pg_regress.
  */
 #define SQL_XID_SNAPSHOT_90200 \
-	"SELECT repack.array_accum(l.virtualtransaction) " \
+	"SELECT coalesce(array_agg(l.virtualtransaction), '{}') " \
 	"  FROM pg_locks AS l " \
 	"  LEFT JOIN pg_stat_activity AS a " \
 	"    ON l.pid = a.pid " \
@@ -90,7 +90,7 @@ const char *PROGRAM_VERSION = "unknown";
 	"  AND ((d.datname IS NULL OR d.datname = current_database()) OR l.database = 0)"
 
 #define SQL_XID_SNAPSHOT_90000 \
-	"SELECT repack.array_accum(l.virtualtransaction) " \
+	"SELECT coalesce(array_agg(l.virtualtransaction), '{}') " \
 	"  FROM pg_locks AS l " \
 	"  LEFT JOIN pg_stat_activity AS a " \
 	"    ON l.pid = a.procpid " \
@@ -108,7 +108,7 @@ const char *PROGRAM_VERSION = "unknown";
  * the WHERE clause is just to eat the $2 parameter (application name).
  */
 #define SQL_XID_SNAPSHOT_80300 \
-	"SELECT repack.array_accum(l.virtualtransaction) " \
+	"SELECT coalesce(array_agg(l.virtualtransaction), '{}') " \
 	"  FROM pg_locks AS l" \
 	"  LEFT JOIN pg_stat_activity AS a " \
 	"    ON l.pid = a.procpid " \

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -40,7 +40,7 @@ Requirements
 ------------
 
 PostgreSQL versions
-    PostgreSQL 9.4, 9.5, 9.6, 10, 11, 12, 13
+    PostgreSQL 9.4, 9.5, 9.6, 10, 11, 12, 13, 14
 
 Disks
     Performing a full-table repack requires free disk space about twice as
@@ -465,6 +465,10 @@ Creating indexes concurrently comes with a few caveats, please see `the document
 
 Releases
 --------
+
+* pg_repack 1.4.7
+
+  * Added support for PostgreSQL 14
 
 * pg_repack 1.4.6
 

--- a/lib/pg_repack.sql.in
+++ b/lib/pg_repack.sql.in
@@ -16,13 +16,6 @@ CREATE FUNCTION repack.version_sql() RETURNS text AS
 $$SELECT 'pg_repack REPACK_VERSION'::text$$
 LANGUAGE SQL IMMUTABLE STRICT;
 
-CREATE AGGREGATE repack.array_accum (
-    sfunc = array_append,
-    basetype = anyelement,
-    stype = anyarray,
-    initcond = '{}'
-);
-
 -- Always specify search_path to 'pg_catalog' so that we
 -- always can get schema-qualified relation name
 CREATE FUNCTION repack.oid2text(oid) RETURNS text AS
@@ -33,7 +26,7 @@ LANGUAGE sql STABLE STRICT SET search_path to 'pg_catalog';
 
 CREATE FUNCTION repack.get_index_columns(oid, text) RETURNS text AS
 $$
-  SELECT array_to_string(repack.array_accum(quote_ident(attname)), $2)
+  SELECT coalesce(string_agg(quote_ident(attname), $2), '')
     FROM pg_attribute,
          (SELECT indrelid,
                  indkey,
@@ -53,8 +46,8 @@ LANGUAGE C STABLE STRICT;
 CREATE FUNCTION repack.get_create_index_type(oid, name) RETURNS text AS
 $$
   SELECT 'CREATE TYPE ' || $2 || ' AS (' ||
-         array_to_string(repack.array_accum(quote_ident(attname) || ' ' ||
-           pg_catalog.format_type(atttypid, atttypmod)), ', ') || ')'
+         coalesce(string_agg(quote_ident(attname) || ' ' ||
+           pg_catalog.format_type(atttypid, atttypmod), ', '), '') || ')'
     FROM pg_attribute,
          (SELECT indrelid,
                  indkey,
@@ -90,9 +83,9 @@ LANGUAGE sql STABLE STRICT;
 
 CREATE FUNCTION repack.get_assign(oid, text) RETURNS text AS
 $$
-  SELECT '(' || array_to_string(repack.array_accum(quote_ident(attname)), ', ') ||
+  SELECT '(' || coalesce(string_agg(quote_ident(attname), ', '), '') ||
          ') = (' || $2 || '.' ||
-         array_to_string(repack.array_accum(quote_ident(attname)), ', ' || $2 || '.') || ')'
+         coalesce(string_agg(quote_ident(attname), ', ' || $2 || '.'), '') || ')'
     FROM (SELECT attname FROM pg_attribute
            WHERE attrelid = $1 AND attnum > 0 AND NOT attisdropped
            ORDER BY attnum) tmp;
@@ -102,9 +95,9 @@ LANGUAGE sql STABLE STRICT;
 CREATE FUNCTION repack.get_compare_pkey(oid, text)
   RETURNS text AS
 $$
-  SELECT '(' || array_to_string(repack.array_accum(quote_ident(attname)), ', ') ||
+  SELECT '(' || coalesce(string_agg(quote_ident(attname), ', '), '') ||
          ') = (' || $2 || '.' ||
-         array_to_string(repack.array_accum(quote_ident(attname)), ', ' || $2 || '.') || ')'
+         coalesce(string_agg(quote_ident(attname), ', ' || $2 || '.'), '') || ')'
     FROM pg_attribute,
          (SELECT indrelid,
                  indkey,
@@ -122,7 +115,7 @@ LANGUAGE sql STABLE STRICT;
 CREATE FUNCTION repack.get_columns_for_create_as(oid)
   RETURNS text AS
 $$
-SELECT array_to_string(repack.array_accum(c), ',') FROM (SELECT
+SELECT coalesce(string_agg(c, ','), '') FROM (SELECT
 	CASE WHEN attisdropped
 		THEN 'NULL::integer AS ' || quote_ident(attname)
 		ELSE quote_ident(attname)
@@ -142,7 +135,7 @@ SELECT
 	'ALTER TABLE ' || $2 || ' ' || array_to_string(dropped_columns, ', ')
 FROM (
 	SELECT
-		repack.array_accum('DROP COLUMN ' || quote_ident(attname)) AS dropped_columns
+		array_agg('DROP COLUMN ' || quote_ident(attname)) AS dropped_columns
 	FROM (
 		SELECT * FROM pg_attribute
 		WHERE attrelid = $1 AND attnum > 0 AND attisdropped
@@ -161,7 +154,7 @@ LANGUAGE sql STABLE STRICT;
 CREATE FUNCTION repack.get_storage_param(oid)
   RETURNS TEXT AS
 $$
-SELECT array_to_string(array_agg(param), ', ')
+SELECT string_agg(param, ', ')
 FROM (
     -- table storage parameter
     SELECT unnest(reloptions) as param
@@ -196,7 +189,7 @@ $$
  SELECT 'ALTER TABLE repack.table_' || $1 || array_to_string(column_storage, ',')
  FROM (
        SELECT
-         repack.array_accum(' ALTER ' || quote_ident(attname) ||
+         array_agg(' ALTER ' || quote_ident(attname) ||
           CASE attstorage
                WHEN 'p' THEN ' SET STORAGE PLAIN'
                WHEN 'm' THEN ' SET STORAGE MAIN'
@@ -222,7 +215,7 @@ LANGUAGE sql STABLE STRICT;
 
 -- includes not only PRIMARY KEYS but also UNIQUE NOT NULL keys
 CREATE VIEW repack.primary_keys AS
-  SELECT indrelid, (repack.array_accum(indexrelid))[1] AS indexrelid
+  SELECT indrelid, min(indexrelid) AS indexrelid
     FROM (SELECT indrelid, indexrelid FROM pg_index
    WHERE indisunique
      AND indisvalid

--- a/lib/repack.c
+++ b/lib/repack.c
@@ -1167,16 +1167,12 @@ swap_heap_or_index_files(Oid r1, Oid r2)
 	relRelation = heap_open(RelationRelationId, RowExclusiveLock);
 #endif
 
-	reltup1 = SearchSysCacheCopy(RELOID,
-								 ObjectIdGetDatum(r1),
-								 0, 0, 0);
+	reltup1 = SearchSysCacheCopy1(RELOID, ObjectIdGetDatum(r1));
 	if (!HeapTupleIsValid(reltup1))
 		elog(ERROR, "cache lookup failed for relation %u", r1);
 	relform1 = (Form_pg_class) GETSTRUCT(reltup1);
 
-	reltup2 = SearchSysCacheCopy(RELOID,
-								 ObjectIdGetDatum(r2),
-								 0, 0, 0);
+	reltup2 = SearchSysCacheCopy1(RELOID, ObjectIdGetDatum(r2));
 	if (!HeapTupleIsValid(reltup2))
 		elog(ERROR, "cache lookup failed for relation %u", r2);
 	relform2 = (Form_pg_class) GETSTRUCT(reltup2);

--- a/regress/expected/repack-check.out
+++ b/regress/expected/repack-check.out
@@ -285,7 +285,7 @@ CREATE TABLE child_b_1(val integer primary key) INHERITS(parent_b);
 CREATE TABLE child_b_2(val integer primary key) INHERITS(parent_b);
 -- => ERROR
 \! pg_repack --dbname=contrib_regression --parent-table=dummy_table
-ERROR: pg_repack failed with error: relation "dummy_table" does not exist
+ERROR: pg_repack failed with error: ERROR:  relation "dummy_table" does not exist
 -- => ERROR
 \! pg_repack --dbname=contrib_regression --parent-table=dummy_index --index=dummy_index
 ERROR: cannot specify --index (-i) and --parent-table (-I)

--- a/regress/expected/repack-check.out
+++ b/regress/expected/repack-check.out
@@ -285,7 +285,7 @@ CREATE TABLE child_b_1(val integer primary key) INHERITS(parent_b);
 CREATE TABLE child_b_2(val integer primary key) INHERITS(parent_b);
 -- => ERROR
 \! pg_repack --dbname=contrib_regression --parent-table=dummy_table
-ERROR: pg_repack failed with error: ERROR:  relation "dummy_table" does not exist
+ERROR: pg_repack failed with error: relation "dummy_table" does not exist
 -- => ERROR
 \! pg_repack --dbname=contrib_regression --parent-table=dummy_index --index=dummy_index
 ERROR: cannot specify --index (-i) and --parent-table (-I)

--- a/regress/travis_prepare.sh
+++ b/regress/travis_prepare.sh
@@ -18,7 +18,7 @@ sudo sed -i "s/main[[:space:]]*$/main ${PGVER}/" \
     /etc/apt/sources.list.d/pgdg.list
 
 if [ "$PGTESTING" != "" ]; then
-    sudo sed -i "s/xenial-pgdg/xenial-pgdg-testing/" \
+    sudo sed -i "s/focal-pgdg/focal-pgdg-testing/" \
         /etc/apt/sources.list.d/pgdg.list
 fi
 

--- a/regress/travis_prepare.sh
+++ b/regress/travis_prepare.sh
@@ -14,8 +14,10 @@ sudo apt-get remove -y libpq5
 
 # Match libpq and server-dev packages
 # See https://github.com/reorg/pg_repack/issues/63
-sudo sed -i "s/main[[:space:]]*$/main ${PGVER}/" \
-    /etc/apt/sources.list.d/pgdg.list
+sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg ${PGVER}" > /etc/apt/sources.list.d/pgdg.list'
+
+# Import the repository signing key:
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 
 if [ "$PGTESTING" != "" ]; then
     sudo sed -i "s/focal-pgdg/focal-pgdg-testing/" \

--- a/regress/travis_prepare.sh
+++ b/regress/travis_prepare.sh
@@ -19,11 +19,6 @@ sudo sh -c 'echo "deb [arch=amd64] http://apt.postgresql.org/pub/repos/apt $(lsb
 # Import the repository signing key:
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 
-if [ "$PGTESTING" != "" ]; then
-    sudo sed -i "s/focal-pgdg/focal-pgdg-testing/" \
-        /etc/apt/sources.list.d/pgdg.list
-fi
-
 sudo apt-get update
 
 # This might be a moving target, but it currently fails. 13 could start

--- a/regress/travis_prepare.sh
+++ b/regress/travis_prepare.sh
@@ -29,6 +29,11 @@ if [[ "$PGVER" = "9.4" ]]; then
     sudo apt-mark hold libpq5
 fi
 
+# missing build dependency by postgresql-server-dev
+if [[ "$PGVER" -ge "14" ]]; then
+    sudo apt-get install -y liblz4-dev
+fi
+
 if ! sudo apt-get install -y \
     postgresql-$PGVER \
     postgresql-client-$PGVER \

--- a/regress/travis_prepare.sh
+++ b/regress/travis_prepare.sh
@@ -14,7 +14,7 @@ sudo apt-get remove -y libpq5
 
 # Match libpq and server-dev packages
 # See https://github.com/reorg/pg_repack/issues/63
-sudo sh -c 'echo "deb [arch=amd64] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg ${PGVER}" > /etc/apt/sources.list.d/pgdg.list'
+sudo sh -c 'echo "deb [arch=amd64] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main ${PGVER}" > /etc/apt/sources.list.d/pgdg.list'
 
 # Import the repository signing key:
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -

--- a/regress/travis_prepare.sh
+++ b/regress/travis_prepare.sh
@@ -14,7 +14,7 @@ sudo apt-get remove -y libpq5
 
 # Match libpq and server-dev packages
 # See https://github.com/reorg/pg_repack/issues/63
-sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg ${PGVER}" > /etc/apt/sources.list.d/pgdg.list'
+sudo sh -c 'echo "deb [arch=amd64] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg ${PGVER}" > /etc/apt/sources.list.d/pgdg.list'
 
 # Import the repository signing key:
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -


### PR DESCRIPTION
Hello
I think I am ready to publish a new patchset to support the postgresql 14 release. I found several changes that we need to address:

- SQL function `array_append` was changed. Most noticeable part, already mentioned in #276 . Instead of fixing the `repack.array_accum` custom aggregate function, I want to drop it and use native PostgreSQL string_agg and array_agg functions instead. They are both old enough.
- API of `simple_prompt` function was changed again
- I replaced few SearchSysCacheCopy calls to encouraged macro. This fixes segfault on pg14 for me, but still not sure why exactly.
- postgresql 14 start producing `CONTEXT:  unnamed portal parameter $2 = '...'` in case of `--table relation_not_exists`. Looks weird. I added explicit check for tables existence
- also I temporary enabled `PGVER=9.6` test on travis. Just for check.

Thanks in advance!