### PR TITLE
Remove connection info from error log

### DIFF
--- a/bin/pgut/pgut.c
+++ b/bin/pgut/pgut.c
@@ -548,8 +548,7 @@ pgut_connect(const char *info, YesNo prompt, int elevel)
 
 		ereport(elevel,
 			(errcode(E_PG_CONNECT),
-			 errmsg("could not connect to database with \"%s\": %s",
-				info, PQerrorMessage(conn))));
+			 errmsg("could not connect to database: %s", PQerrorMessage(conn))));
 		PQfinish(conn);
 		return NULL;
 	}


### PR DESCRIPTION
Removing connection info from error log, which can include sensitive info such as DB password. 

Addresses this issue: https://github.com/reorg/pg_repack/issues/285