### PR TITLE
Use the correct article for abbreviations

### DIFF
--- a/bin/pgut/pgut-fe.c
+++ b/bin/pgut/pgut-fe.c
@@ -573,7 +573,7 @@ parse_pair(const char buffer[], char key[], char value[])
 }
 
 /*
- * execute - Execute a SQL and return the result.
+ * execute - Execute an SQL and return the result.
  */
 PGresult *
 execute(const char *query, int nParams, const char **params)
@@ -588,7 +588,7 @@ execute_elevel(const char *query, int nParams, const char **params, int elevel)
 }
 
 /*
- * command - Execute a SQL and discard the result.
+ * command - Execute an SQL and discard the result.
  */
 ExecStatusType
 command(const char *query, int nParams, const char **params)

--- a/lib/pg_repack.sql.in
+++ b/lib/pg_repack.sql.in
@@ -126,7 +126,7 @@ WHERE attrelid = $1 AND attnum > 0 ORDER BY attnum
 $$
 LANGUAGE sql STABLE STRICT;
 
--- Get a SQL text to DROP dropped columns for the table,
+-- Get an SQL text to DROP dropped columns for the table,
 -- or NULL if it has no dropped columns.
 CREATE FUNCTION repack.get_drop_columns(oid, text)
   RETURNS text AS
@@ -182,7 +182,7 @@ FROM (
 $$
 LANGUAGE sql STABLE STRICT;
 
--- GET a SQL text to set column storage option for the table.
+-- GET an SQL text to set column storage option for the table.
 CREATE FUNCTION repack.get_alter_col_storage(oid)
   RETURNS text AS
 $$


### PR DESCRIPTION
We've accumulated quite a mix of instances of "an SQL" and "a SQL" in the
documents.  It would be good to be a bit more consistent with these.

The most recent version of the SQL standard I looked at seems to prefer
"an SQL".  That seems like a good lead to follow, so here we change all
instances of "a SQL" to become "an SQL".  Most instances correctly use
"an SQL" already, so it also makes sense to use the dominant variation in
order to minimise churn.