### PR TITLE
Take ACCESS EXCLUSIVE LOCK carefully

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -1280,7 +1280,7 @@ repack_one_table(repack_table *table, const char *orderby)
 		return;
 
 	/* push repack_cleanup_callback() on stack to clean temporary objects */
-	pgut_atexit_push(repack_cleanup_callback, &table->target_oid);
+	pgut_atexit_push(repack_cleanup_callback, table);
 
 	/*
 	 * 1. Setup advisory lock and trigger on main table.
@@ -1970,7 +1970,8 @@ lock_exclusive(PGconn *conn, const char *relid, const char *lock_query, bool sta
 void
 repack_cleanup_callback(bool fatal, void *userdata)
 {
-	Oid			target_table = *(Oid *) userdata;
+	repack_table *table = (repack_table *) userdata;
+	Oid			target_table = table->target_oid;
 	const char *params[2];
 	char		buffer[12];
 	char		num_buff[12];
@@ -1985,7 +1986,16 @@ repack_cleanup_callback(bool fatal, void *userdata)
 		 * so just use an unconditional reconnect().
 		 */
 		reconnect(ERROR);
+
+		command("BEGIN ISOLATION LEVEL READ COMMITTED", 0, NULL);
+		if (!(lock_exclusive(connection, params[0], table->lock_table, false)))
+		{
+			elog(ERROR, "lock_exclusive() failed in connection for %s during cleanup callback",
+				 table->target_name);
+		}
+
 		command("SELECT repack.repack_drop($1, $2)", 2, params);
+		command("COMMIT", 0, NULL);
 		temp_obj_num = 0; /* reset temporary object counter after cleanup */
 	}
 }
@@ -2015,7 +2025,16 @@ repack_cleanup(bool fatal, const repack_table *table)
 		/* do cleanup */
 		params[0] = utoa(table->target_oid, buffer);
 		params[1] =  utoa(temp_obj_num, num_buff);
+
+		command("BEGIN ISOLATION LEVEL READ COMMITTED", 0, NULL);
+		if (!(lock_exclusive(connection, params[0], table->lock_table, false)))
+		{
+			elog(ERROR, "lock_exclusive() failed in connection for %s during cleanup",
+				 table->target_name);
+		}
+
 		command("SELECT repack.repack_drop($1, $2)", 2, params);
+		command("COMMIT", 0, NULL);
 		temp_obj_num = 0; /* reset temporary object counter after cleanup */
 	}
 }

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -1990,6 +1990,7 @@ repack_cleanup_callback(bool fatal, void *userdata)
 		command("BEGIN ISOLATION LEVEL READ COMMITTED", 0, NULL);
 		if (!(lock_exclusive(connection, params[0], table->lock_table, false)))
 		{
+			pgut_rollback(connection);
 			elog(ERROR, "lock_exclusive() failed in connection for %s during cleanup callback",
 				 table->target_name);
 		}
@@ -2029,6 +2030,7 @@ repack_cleanup(bool fatal, const repack_table *table)
 		command("BEGIN ISOLATION LEVEL READ COMMITTED", 0, NULL);
 		if (!(lock_exclusive(connection, params[0], table->lock_table, false)))
 		{
+			pgut_rollback(connection);
 			elog(ERROR, "lock_exclusive() failed in connection for %s during cleanup",
 				 table->target_name);
 		}

--- a/bin/pgut/pgut.h
+++ b/bin/pgut/pgut.h
@@ -51,7 +51,7 @@ extern const char  *PROGRAM_ISSUES;
 extern bool		interrupted;
 extern int		pgut_log_level;
 extern int		pgut_abort_level;
-extern bool		pgut_echo;	
+extern bool		pgut_echo;
 
 extern void pgut_init(int argc, char **argv);
 extern void pgut_atexit_push(pgut_atexit_callback callback, void *userdata);


### PR DESCRIPTION
Try to get the lock in loop with timeouts using `lock_exclusive()`. This allows to not stuck lock queue for readers if pg_repack cannot take the lock fast enough.

We had incidents when cleanup functions, which run `repack.repack_drop()`, couldn't get ACCESS EXCLUSIVE lock in a reasonable time. It was because there was long running write connections, running around 5-10 minutes. `repack.repack_drop()` also stucks lock queue block any new readers until all old writes finish.