### PR TITLE
Fix infinite loop when an empty or blank password is given

### DIFF
--- a/bin/pgut/pgut-fe.c
+++ b/bin/pgut/pgut-fe.c
@@ -63,7 +63,7 @@ setup_workers(int num_workers)
  		if (username && username[0])
  			appendStringInfo(&buf, "user=%s ", username);
  		if (password && password[0])
- 			appendStringInfo(&buf, "password=%s ", password);
+ 			appendStringInfo(&buf, "password='%s' ", password);
 
  		if (workers.conns == NULL)
  		{
@@ -169,7 +169,7 @@ reconnect(int elevel)
 	if (username && username[0])
 		appendStringInfo(&buf, "user=%s ", username);
 	if (password && password[0])
-		appendStringInfo(&buf, "password=%s ", password);
+		appendStringInfo(&buf, "password='%s' ", password);
 
 	connection = pgut_connect(buf.data, prompt_password, elevel);
 	conn2      = pgut_connect(buf.data, prompt_password, elevel);

--- a/bin/pgut/pgut.c
+++ b/bin/pgut/pgut.c
@@ -449,7 +449,9 @@ prompt_for_password(void)
 		buf = pgut_malloc(BUFSIZE);
 		memcpy(buf, passwdbuf, sizeof(char)*BUFSIZE);
 	} else {
-		buf = simple_prompt("Password: ", BUFSIZE, false);
+		do {
+			buf = simple_prompt("Password: ", BUFSIZE, false);
+		} while (strlen(buf) == 0);
 		have_passwd = true;
 		passwdbuf = pgut_malloc(BUFSIZE);
 		memcpy(passwdbuf, buf, sizeof(char)*BUFSIZE);
@@ -459,8 +461,11 @@ prompt_for_password(void)
 	if (have_passwd) {
 		memcpy(buf, passwdbuf, sizeof(char)*BUFSIZE);
 	} else {
-		if (buf != NULL)
-			simple_prompt("Password: ", buf, BUFSIZE, false);
+		if (buf != NULL) {
+			do {
+				simple_prompt("Password: ", buf, BUFSIZE, false);
+			} while (strlen(buf) == 0);
+		}
 		have_passwd = true;
 		passwdbuf = pgut_malloc(BUFSIZE);
 		memcpy(passwdbuf, buf, sizeof(char)*BUFSIZE);
@@ -470,7 +475,9 @@ prompt_for_password(void)
 		buf = pgut_malloc(BUFSIZE);
 		memcpy(buf, passwdbuf, sizeof(char)*BUFSIZE);
 	} else {
-		buf = simple_prompt("Password: ", false);
+		do {
+			buf = simple_prompt("Password: ", false);
+		} while (strlen(buf) == 0);
 		have_passwd = true;
 		passwdbuf = pgut_malloc(BUFSIZE);
 		memcpy(passwdbuf, buf, sizeof(char)*BUFSIZE);
@@ -500,7 +507,7 @@ pgut_connect(const char *info, YesNo prompt, int elevel)
 		passwd = prompt_for_password();
 		initStringInfo(&add_pass);
 		appendStringInfoString(&add_pass, info);
-		appendStringInfo(&add_pass, " password=%s ", passwd);
+		appendStringInfo(&add_pass, " password='%s' ", passwd);
 	}
 	else
 	{
@@ -552,7 +559,7 @@ pgut_connect(const char *info, YesNo prompt, int elevel)
 			else
 	 			initStringInfo(&add_pass);
 			appendStringInfoString(&add_pass, info);
-			appendStringInfo(&add_pass, " password=%s ", passwd);
+			appendStringInfo(&add_pass, " password='%s' ", passwd);
 			continue;
 		}
 


### PR DESCRIPTION
This is fix for #299.

The connection string used by pg_repack was missing password quotes.
It also adds retry processing so that if an empty password is entered, the password prompt does not remember it.
