### PR TITLE
support for postgresql 15

### DIFF
--- a/bin/pgut/pgut-fe.h
+++ b/bin/pgut/pgut-fe.h
@@ -57,7 +57,7 @@ typedef struct worker_conns
 
 
 
-extern char	   *dbname;
+extern const char  *dbname;
 extern char	   *host;
 extern char	   *port;
 extern char	   *username;


### PR DESCRIPTION
Postgresql 15 beta1 is here. Luckily, we only have one minor change: postgresql commit 98e93a1fc93e9b54eb477d870ec744e9e1669f34 removed include of pwd.h and breaks build. I decided to replace your own implementation of get_username and use the generic get_user_name_or_exit from the postgresql code. Exists since postgresql 9.4, so no change in supported versions.