### PR TITLE
Fix segfault in get_order_by function

### DIFF
--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -466,6 +466,10 @@ Creating indexes concurrently comes with a few caveats, please see `the document
 Releases
 --------
 
+* pg_repack 1.4.9 (unreleased)
+
+  * Fixed crash in ``get_order_by()`` using invalid relations (issue #321)
+
 * pg_repack 1.4.8
 
   * Added support for PostgreSQL 15

--- a/lib/repack.c
+++ b/lib/repack.c
@@ -373,6 +373,9 @@ get_relation_name(Oid relid)
 	char   *strver;
 	int ver;
 
+	if (!OidIsValid(nsp))
+		elog(ERROR, "table name not found for OID %u", relid);
+
 	/* Get the version of the running server (PG_VERSION_NUM would return
 	 * the version we compiled the extension with) */
 	strver = GetConfigOptionByName("server_version_num", NULL

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -17,7 +17,7 @@ INTVERSION := $(shell echo $$(($$(echo $(VERSION).0 | sed 's/\([[:digit:]]\{1,\}
 # Test suite
 #
 
-REGRESS := init-extension repack-setup repack-run after-schema repack-check nosuper tablespace issue3
+REGRESS := init-extension repack-setup repack-run after-schema repack-check nosuper tablespace get_order_by
 
 USE_PGXS = 1	# use pgxs if not in contrib directory
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/regress/expected/get_order_by.out
+++ b/regress/expected/get_order_by.out
@@ -51,3 +51,12 @@ SELECT repack.get_order_by('issue3_5_idx'::regclass::oid, 'issue3_5'::regclass::
 
 \! pg_repack --dbname=contrib_regression --table=issue3_5
 INFO: repacking table "public.issue3_5"
+--
+-- pg_repack issue #321
+--
+CREATE TABLE issue321 (col1 int NOT NULL, col2 text NOT NULL);
+CREATE UNIQUE INDEX issue321_idx ON issue321 (col1);
+SELECT repack.get_order_by('issue321_idx'::regclass::oid, 1);
+ERROR:  table name not found for OID 1
+SELECT repack.get_order_by(1, 1);
+ERROR:  cache lookup failed for index 1

--- a/regress/sql/get_order_by.sql
+++ b/regress/sql/get_order_by.sql
@@ -25,3 +25,11 @@ CREATE TABLE issue3_5 (col1 int NOT NULL, col2 text NOT NULL);
 CREATE UNIQUE INDEX issue3_5_idx ON issue3_5 (col1 DESC NULLS FIRST, col2 COLLATE "POSIX" DESC);
 SELECT repack.get_order_by('issue3_5_idx'::regclass::oid, 'issue3_5'::regclass::oid);
 \! pg_repack --dbname=contrib_regression --table=issue3_5
+
+--
+-- pg_repack issue #321
+--
+CREATE TABLE issue321 (col1 int NOT NULL, col2 text NOT NULL);
+CREATE UNIQUE INDEX issue321_idx ON issue321 (col1);
+SELECT repack.get_order_by('issue321_idx'::regclass::oid, 1);
+SELECT repack.get_order_by(1, 1);


### PR DESCRIPTION
When pass an invalid Oid to `get_order_by` function it lead to a segmentation full in function `get_relation_name`.

Fixed if by raising an error when a table is not found.

Fixes #321