### PR TITLE
Bump checkout github action version

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -26,7 +26,7 @@ jobs:
         run: apt-get install -y liblz4-dev libreadline-dev zlib1g-dev libzstd-dev
 
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Put pg_repack on PATH
         run: echo "$PWD/bin" >> $GITHUB_PATH


### PR DESCRIPTION
All github actions that run on Node12 are deprecated so bumped `checkout` github action version to run on Node16.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/