### PR TITLE
pg_repack.c

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -884,7 +884,13 @@ repack_one_database(const char *orderby, char *errbuf, size_t errsize)
 	}
 
 	num = PQntuples(res);
-
+	/* Issue#260 Fix: show warning for invalid schema, but only when only 1 schema is provided. */
+	/* If other valid schemas are provided, do not show warning for any invalid ones. */
+        if (num == 0) {
+		   ereport(WARNING,
+                                (errcode(E_PG_COMMAND),
+                                 errmsg("No relations found.")));
+        }
 	for (i = 0; i < num; i++)
 	{
 		repack_table	table;


### PR DESCRIPTION
Fixes Issue#260.
If the user provides multiple schemas and one or more of them are valid, then the only output will be the repacking of the valid schema tables. There is no warning output for the invalid schemas in these cases. Only when a single, invalid schema is provided will a warning output be produced.  Hopefully, this time you wont find extra white space to make doing diffs difficult.

Elaborating further... the current architecture branch for schema logic works by constructing a query to bring back all the tables for all the schemas provided.  It does not check whether any of the schemas brought back nothing, i.e.., a bad schema or a valid schema with no tables.  Uses SCHEMANAME IN list construct.