### PR TITLE
support for postgresql 16

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -7,6 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         pg:
+          - 16
           - 15
           - 14
           - 13


### PR DESCRIPTION
Hello

So far there are no incompatible changes, 1.4.8 works with postgresql 16dev without any changes.

However, I propose to prepare a new release 1.4.9 as usual, I will mention postgresql 16 support in the change notes to eliminate any ambiguity.

Question for discussion: it is necessary to change the list of supported old versions? ( #338 )

PS: at the same time I want to check if pg16 is already available for our tests