### PR TITLE
Rebase: new option "switch-threshold"

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -2386,5 +2386,5 @@ pgut_help(bool details)
 	printf("  -Z, --no-analyze          don't analyze at end\n");
 	printf("  -k, --no-superuser-check  skip superuser checks in client\n");
 	printf("  -C, --exclude-extension   don't repack tables which belong to specific extension\n");
-	printf("  -t, --switch-threshold    switch tables when that many tuples are left to catchup\n");
+	printf("      --switch-threshold    switch tables when that many tuples are left to catchup\n");
 }

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -51,7 +51,7 @@ const char *PROGRAM_VERSION = "unknown";
 /* Once we get down to seeing fewer than this many tuples in the
  * log table, we'll say that we're ready to perform the switch.
  */
-#define MIN_TUPLES_BEFORE_SWITCH	20
+#define SWITCH_THRESHOLD_DEFAULT	100
 
 /* poll() or select() timeout, in seconds */
 #define POLL_TIMEOUT    3
@@ -257,6 +257,7 @@ static bool				no_kill_backend = false; /* abandon when timed-out */
 static bool				no_superuser_check = false;
 static SimpleStringList	exclude_extension_list = {NULL, NULL}; /* don't repack tables of these extensions */
 static bool 			error_on_invalid_index = false; /* don't repack when invalid index is found */
+static int				switch_threshold = SWITCH_THRESHOLD_DEFAULT;
 
 /* buffer should have at least 11 bytes */
 static char *
@@ -287,6 +288,7 @@ static pgut_option options[] =
 	{ 'b', 'k', "no-superuser-check", &no_superuser_check },
 	{ 'l', 'C', "exclude-extension", &exclude_extension_list },
 	{ 'b', 'F', "error-on-invalid-index", &error_on_invalid_index },
+	{ 'i', 1, "switch-threshold", &switch_threshold },
 	{ 0 },
 };
 
@@ -1560,12 +1562,12 @@ repack_one_table(repack_table *table, const char *orderby)
 		/* We'll keep applying tuples from the log table in batches
 		 * of APPLY_COUNT, until applying a batch of tuples
 		 * (via LIMIT) results in our having applied
-		 * MIN_TUPLES_BEFORE_SWITCH or fewer tuples. We don't want to
+		 * switch_threshold or fewer tuples. We don't want to
 		 * get stuck repetitively applying some small number of tuples
 		 * from the log table as inserts/updates/deletes may be
 		 * constantly coming into the original table.
 		 */
-		if (num > MIN_TUPLES_BEFORE_SWITCH)
+		if (num > switch_threshold)
 			continue;	/* there might be still some tuples, repeat. */
 
 		/* old transactions still alive ? */
@@ -2384,4 +2386,5 @@ pgut_help(bool details)
 	printf("  -Z, --no-analyze          don't analyze at end\n");
 	printf("  -k, --no-superuser-check  skip superuser checks in client\n");
 	printf("  -C, --exclude-extension   don't repack tables which belong to specific extension\n");
+	printf("  -t, --switch-threshold    switch tables when that many tuples are left to catchup\n");
 }

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -124,6 +124,7 @@ Options:
   -k, --no-superuser-check      skip superuser checks in client
   -C, --exclude-extension       don't repack tables which belong to specific extension
   -F, --error-on-invalid-index  don't repack when invalid index is found
+      --switch-threshold        switch tables when that many tuples are left to catchup
 
 Connection options:
   -d, --dbname=DBNAME           database to connect
@@ -224,6 +225,10 @@ Reorg Options
 ``-C``, ``--exclude-extension``
     Skip tables that belong to the specified extension(s). Some extensions
     may heavily depend on such tables at planning time etc.
+
+``--switch-threshold``
+    Switch tables when that many tuples are left in log table.
+    This setting can be used to avoid the inability to catchup with write-heavy tables.
 
 Connection Options
 ^^^^^^^^^^^^^^^^^^

--- a/doc/pg_repack_jp.rst
+++ b/doc/pg_repack_jp.rst
@@ -212,6 +212,7 @@ pg_repackもしくはpg_reorgの古いバージョンからのアップグレー
     -k, --no-superuser-check      skip superuser checks in client
     -C, --exclude-extension       don't repack tables which belong to specific extension
     -F, --error-on-invalid-index  don't repack when invalid index is found
+        --switch-threshold        switch tables when that many tuples are left to catchup
   
   Connection options:
     -d, --dbname=DBNAME           database to connect

--- a/regress/expected/repack-check.out
+++ b/regress/expected/repack-check.out
@@ -333,3 +333,8 @@ INFO: repacking indexes of "public.child_b_2"
 INFO: repacking index "public.child_b_2_pkey"
 INFO: repacking indexes of "public.parent_b"
 INFO: repacking index "public.parent_b_pkey"
+--
+-- Switch threshold
+--
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --switch-threshold 200
+INFO: repacking table "public.tbl_cluster"

--- a/regress/sql/repack-check.sql
+++ b/regress/sql/repack-check.sql
@@ -168,3 +168,8 @@ CREATE TABLE child_b_2(val integer primary key) INHERITS(parent_b);
 \! pg_repack --dbname=contrib_regression --table=parent_a --parent-table=parent_b --only-indexes
 -- => OK
 \! pg_repack --dbname=contrib_regression --parent-table=parent_a --parent-table=parent_b --only-indexes
+
+--
+-- Switch threshold
+--
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --switch-threshold 200


### PR DESCRIPTION
This is rebased patch from https://github.com/reorg/pg_repack/pull/261.

Differences:
- There is no unnecessary short option name `-r`
- Default threshold value is `100`
- New test for `--switch-threshold`