### PR TITLE
Remove unnecessary short option name for `--error-on-invalid-index`

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -286,7 +286,7 @@ static pgut_option options[] =
 	{ 'b', 'D', "no-kill-backend", &no_kill_backend },
 	{ 'b', 'k', "no-superuser-check", &no_superuser_check },
 	{ 'l', 'C', "exclude-extension", &exclude_extension_list },
-	{ 'b', 'F', "error-on-invalid-index", &error_on_invalid_index },
+	{ 'b', 2, "error-on-invalid-index", &error_on_invalid_index },
 	{ 0 },
 };
 
@@ -2367,21 +2367,22 @@ pgut_help(bool details)
 		return;
 
 	printf("Options:\n");
-	printf("  -a, --all                 repack all databases\n");
-	printf("  -t, --table=TABLE         repack specific table only\n");
-	printf("  -I, --parent-table=TABLE  repack specific parent table and its inheritors\n");
-	printf("  -c, --schema=SCHEMA       repack tables in specific schema only\n");
-	printf("  -s, --tablespace=TBLSPC   move repacked tables to a new tablespace\n");
-	printf("  -S, --moveidx             move repacked indexes to TBLSPC too\n");
-	printf("  -o, --order-by=COLUMNS    order by columns instead of cluster keys\n");
-	printf("  -n, --no-order            do vacuum full instead of cluster\n");
-	printf("  -N, --dry-run             print what would have been repacked\n");
-	printf("  -j, --jobs=NUM            Use this many parallel jobs for each table\n");
-	printf("  -i, --index=INDEX         move only the specified index\n");
-	printf("  -x, --only-indexes        move only indexes of the specified table\n");
-	printf("  -T, --wait-timeout=SECS   timeout to cancel other backends on conflict\n");
-	printf("  -D, --no-kill-backend     don't kill other backends when timed out\n");
-	printf("  -Z, --no-analyze          don't analyze at end\n");
-	printf("  -k, --no-superuser-check  skip superuser checks in client\n");
-	printf("  -C, --exclude-extension   don't repack tables which belong to specific extension\n");
+	printf("  -a, --all                     repack all databases\n");
+	printf("  -t, --table=TABLE             repack specific table only\n");
+	printf("  -I, --parent-table=TABLE      repack specific parent table and its inheritors\n");
+	printf("  -c, --schema=SCHEMA           repack tables in specific schema only\n");
+	printf("  -s, --tablespace=TBLSPC       move repacked tables to a new tablespace\n");
+	printf("  -S, --moveidx                 move repacked indexes to TBLSPC too\n");
+	printf("  -o, --order-by=COLUMNS        order by columns instead of cluster keys\n");
+	printf("  -n, --no-order                do vacuum full instead of cluster\n");
+	printf("  -N, --dry-run                 print what would have been repacked\n");
+	printf("  -j, --jobs=NUM                Use this many parallel jobs for each table\n");
+	printf("  -i, --index=INDEX             move only the specified index\n");
+	printf("  -x, --only-indexes            move only indexes of the specified table\n");
+	printf("  -T, --wait-timeout=SECS       timeout to cancel other backends on conflict\n");
+	printf("  -D, --no-kill-backend         don't kill other backends when timed out\n");
+	printf("  -Z, --no-analyze              don't analyze at end\n");
+	printf("  -k, --no-superuser-check      skip superuser checks in client\n");
+	printf("  -C, --exclude-extension       don't repack tables which belong to specific extension\n");
+	printf("      --error-on-invalid-index  don't repack tables which belong to specific extension\n");
 }

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -123,7 +123,7 @@ Options:
   -Z, --no-analyze              don't analyze at end
   -k, --no-superuser-check      skip superuser checks in client
   -C, --exclude-extension       don't repack tables which belong to specific extension
-  -F, --error-on-invalid-index  don't repack when invalid index is found
+      --error-on-invalid-index  don't repack when invalid index is found
 
 Connection options:
   -d, --dbname=DBNAME           database to connect

--- a/doc/pg_repack_jp.rst
+++ b/doc/pg_repack_jp.rst
@@ -211,7 +211,7 @@ pg_repackもしくはpg_reorgの古いバージョンからのアップグレー
     -Z, --no-analyze              don't analyze at end
     -k, --no-superuser-check      skip superuser checks in client
     -C, --exclude-extension       don't repack tables which belong to specific extension
-    -F, --error-on-invalid-index  don't repack when invalid index is found
+        --error-on-invalid-index  don't repack when invalid index is found
   
   Connection options:
     -d, --dbname=DBNAME           database to connect


### PR DESCRIPTION
The option `-F, --error-on-invalid-index` was added by https://github.com/reorg/pg_repack/pull/336.
Short name for this option is unnecessary and can be removed.