### PR TITLE
Check if a password already was prompted

### DIFF
--- a/bin/pgut/pgut.c
+++ b/bin/pgut/pgut.c
@@ -542,10 +542,9 @@ pgut_connect(const char *info, YesNo prompt, int elevel)
 			return conn;
 		}
 
-		if (conn && PQconnectionNeedsPassword(conn) && prompt != NO)
+		if (conn && PQconnectionNeedsPassword(conn) && !passwd && prompt != NO)
 		{
 			PQfinish(conn);
-			free(passwd);
 			passwd = prompt_for_password();
 			if (add_pass.data != NULL)
 	 			resetStringInfo(&add_pass);
@@ -682,7 +681,7 @@ pgut_command(PGconn* conn, const char *query, int nParams, const char **params)
 {
 	PGresult	   *res;
 	ExecStatusType	code;
-	
+
 	res = pgut_execute(conn, query, nParams, params);
 	code = PQresultStatus(res);
 	PQclear(res);


### PR DESCRIPTION
This fixes infinite loop in case of an empty password.
The issue #299.

There is another PR #303 which fixes the issue. But it adds another infinite loop and it isn't consistent with the behavior when a user inputs wrong password.

In case of a wrong password pg_repack throws an error like:
```
ERROR: could not connect to database: connection to server on socket "/tmp/.s.PGSQL.5432" failed: FATAL:  password authentication failed for user "repack_user"
```
and it doesn't go to another loop and doesn't ask for another password.

In case of an empty password with this PR pg_repack will throw an error like:
```
ERROR: could not connect to database: connection to server on socket "/tmp/.s.PGSQL.5432" failed: fe_sendauth: no password supplied
```