### PR TITLE
Support larger password lengths v2

### DIFF
--- a/bin/pgut/pgut.c
+++ b/bin/pgut/pgut.c
@@ -442,7 +442,7 @@ prompt_for_password(void)
 	static char *passwdbuf;
 	static bool have_passwd = false;
 
-#define BUFSIZE 100
+#define BUFSIZE 1024
 
 #if PG_VERSION_NUM < 100000
 	if (have_passwd) {

--- a/bin/pgut/pgut.c
+++ b/bin/pgut/pgut.c
@@ -442,6 +442,10 @@ prompt_for_password(void)
 	static char *passwdbuf;
 	static bool have_passwd = false;
 
+#if PG_VERSION_NUM >= 140000
+	static size_t passwd_size = 0;
+#endif
+
 #define BUFSIZE 1024
 
 #if PG_VERSION_NUM < 100000
@@ -467,13 +471,15 @@ prompt_for_password(void)
 	}
 #else
 	if (have_passwd) {
-		buf = pgut_malloc(BUFSIZE);
-		memcpy(buf, passwdbuf, sizeof(char)*BUFSIZE);
+		buf = pgut_malloc(passwd_size);
+		memcpy(buf, passwdbuf, sizeof(char) * passwd_size);
 	} else {
 		buf = simple_prompt("Password: ", false);
+		passwd_size = strlen(buf) + 1;
 		have_passwd = true;
-		passwdbuf = pgut_malloc(BUFSIZE);
-		memcpy(passwdbuf, buf, sizeof(char)*BUFSIZE);
+
+		passwdbuf = pgut_malloc(passwd_size);
+		memcpy(passwdbuf, buf, sizeof(char) * passwd_size);
 	}
 #endif
 
@@ -682,7 +688,7 @@ pgut_command(PGconn* conn, const char *query, int nParams, const char **params)
 {
 	PGresult	   *res;
 	ExecStatusType	code;
-	
+
 	res = pgut_execute(conn, query, nParams, params);
 	code = PQresultStatus(res);
 	PQclear(res);


### PR DESCRIPTION
This PR enhances https://github.com/reorg/pg_repack/pull/350. In addition to increasing of buffer size it removes restrictions on password length for Postgres 14+.

As it was discussed starting from [this comment](https://github.com/reorg/pg_repack/pull/350#issuecomment-1516559391) it is possible to remove the restriction completely by copying `simple_prompt` function from the Postgres 14+ source code into pg_repack code base. But this looks more complicate than removing the restriction only for Postgres 14+, because it will be necessary to support that code in the future.

It is possible to remove the restriction completely in the future if it will be decided that it is better.