### PR TITLE
Support  for exclude table  ( -X ) and exclude parent table ( -Y )

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,11 +6,11 @@ pg_repack -- Reorganize tables in PostgreSQL databases with minimal locks
 - Development: https://github.com/reorg/pg_repack
 - Bug Report: https://github.com/reorg/pg_repack/issues
 
-|travis|
+|GitHub Actions|
 
-.. |travis| image:: https://travis-ci.org/reorg/pg_repack.svg?branch=master
-    :target: https://travis-ci.org/reorg/pg_repack
-    :alt: Linux and OSX build status
+.. |GitHub Actions| image:: https://github.com/reorg/pg_repack/actions/workflows/regression.yml/badge.svg
+   :target: https://github.com/reorg/pg_repack/actions/workflows/regression.yml
+   :alt: Linux build status
 
 pg_repack_ is a PostgreSQL extension which lets you remove bloat from
 tables and indexes, and optionally restore the physical order of clustered

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -373,6 +373,11 @@ main(int argc, char *argv[])
 			ereport(ERROR,
 				(errcode(EINVAL),
 					errmsg("cannot specify --exclude-table (-X) along with --table (-t), --parent-table (-I) and --exclude-extension (-C)")));
+		
+		if (exclude_parent_table_list.head && (table_list.head || parent_table_list.head || exclude_extension_list.head))
+			ereport(ERROR,
+				(errcode(EINVAL),
+					errmsg("cannot specify --exclude-parent-table (-Y) along with --table (-t), --parent-table (-I) and --exclude-extension (-C)")));
 
 		if (exclude_extension_list.head && table_list.head)
 			ereport(ERROR,

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -243,6 +243,7 @@ static bool				alldb = false;
 static bool				noorder = false;
 static SimpleStringList	parent_table_list = {NULL, NULL};
 static SimpleStringList	table_list = {NULL, NULL};
+static SimpleStringList exclude_table_list = {NULL, NULL};
 static SimpleStringList	schema_list = {NULL, NULL};
 static char				*orderby = NULL;
 static char				*tablespace = NULL;
@@ -287,6 +288,7 @@ static pgut_option options[] =
 	{ 'b', 'D', "no-kill-backend", &no_kill_backend },
 	{ 'b', 'k', "no-superuser-check", &no_superuser_check },
 	{ 'l', 'C', "exclude-extension", &exclude_extension_list },
+	{ 'l', 'X', "exclude-table", &exclude_table_list },
 	{ 'b', 2, "error-on-invalid-index", &error_on_invalid_index },
 	{ 'i', 1, "switch-threshold", &switch_threshold },
 	{ 0 },
@@ -333,6 +335,9 @@ main(int argc, char *argv[])
 		else if (only_indexes && exclude_extension_list.head)
 			ereport(ERROR, (errcode(EINVAL),
 				errmsg("cannot specify --only-indexes (-x) and --exclude-extension (-C)")));
+		else if ((only_indexes || r_index.head) && exclude_table_list.head)
+            ereport(ERROR, (errcode(EINVAL),
+                errmsg("cannot specify --only-indexes (-x) or --index (-i) with --exclude-table (-X)")));
 		else if (alldb)
 			ereport(ERROR, (errcode(EINVAL),
 				errmsg("cannot repack specific index(es) in all databases")));
@@ -357,10 +362,15 @@ main(int argc, char *argv[])
 	}
 	else
 	{
-		if (schema_list.head && (table_list.head || parent_table_list.head))
+		if (schema_list.head && (table_list.head || parent_table_list.head || exclude_table_list.head))
 			ereport(ERROR,
 				(errcode(EINVAL),
-				 errmsg("cannot repack specific table(s) in schema, use schema.table notation instead")));
+				 errmsg("cannot repack/exclude specific table(s) in schema, use schema.table notation instead")));
+
+		if (exclude_table_list.head && (table_list.head || parent_table_list.head || exclude_extension_list.head))
+			ereport(ERROR,
+				(errcode(EINVAL),
+					errmsg("cannot specify --exclude-table (-X) along with --table (-t), --parent-table (-I) and --exclude-extension (-C)")));
 
 		if (exclude_extension_list.head && table_list.head)
 			ereport(ERROR,
@@ -385,6 +395,10 @@ main(int argc, char *argv[])
 				ereport(ERROR,
 					(errcode(EINVAL),
 					 errmsg("cannot repack specific schema(s) in all databases")));
+			if (exclude_table_list.head)
+                ereport(ERROR,
+					(errcode(EINVAL),
+						errmsg("cannot exclude specific tables(s) in all databases")));
 			repack_all_databases(orderby);
 		}
 		else
@@ -579,7 +593,8 @@ is_requested_relation_exists(char *errbuf, size_t errsize){
 	SimpleStringListCell   *cell;
 
 	num_relations = simple_string_list_size(parent_table_list) +
-					simple_string_list_size(table_list);
+					simple_string_list_size(table_list)+
+					simple_string_list_size(exclude_table_list);
 
 	/* nothing was implicitly requested, so nothing to do here */
 	if (num_relations == 0)
@@ -594,6 +609,13 @@ is_requested_relation_exists(char *errbuf, size_t errsize){
 	appendStringInfoString(&sql, "SELECT r FROM (VALUES ");
 
 	for (cell = table_list.head; cell; cell = cell->next)
+	{
+		appendStringInfo(&sql, "($%d, 'r')", iparam + 1);
+		params[iparam++] = cell->val;
+		if (iparam < num_relations)
+			appendStringInfoChar(&sql, ',');
+	}
+	for (cell = exclude_table_list.head; cell; cell = cell->next)
 	{
 		appendStringInfo(&sql, "($%d, 'r')", iparam + 1);
 		params[iparam++] = cell->val;
@@ -749,18 +771,21 @@ repack_one_database(const char *orderby, char *errbuf, size_t errsize)
 							num_tables,
 							num_schemas,
 							num_params,
-							num_excluded_extensions;
+							num_excluded_extensions,
+							num_excluded_tables;
 
 	num_parent_tables = simple_string_list_size(parent_table_list);
 	num_tables = simple_string_list_size(table_list);
 	num_schemas = simple_string_list_size(schema_list);
 	num_excluded_extensions = simple_string_list_size(exclude_extension_list);
+	num_excluded_tables = simple_string_list_size(exclude_table_list);
 
 	/* 1st param is the user-specified tablespace */
 	num_params = num_excluded_extensions +
 				 num_parent_tables +
 				 num_tables +
-				 num_schemas + 1;
+				 num_schemas +
+				 num_excluded_tables + 1;
 	params = pgut_malloc(num_params * sizeof(char *));
 
 	initStringInfo(&sql);
@@ -833,6 +858,20 @@ repack_one_database(const char *orderby, char *errbuf, size_t errsize)
 			params[iparam++] = cell->val;
 			if (cell->next)
 				appendStringInfoString(&sql, ", ");
+		}
+		appendStringInfoString(&sql, ")");
+	}
+	else if (num_excluded_tables)
+	{
+		appendStringInfoString(&sql, "(");
+		for (cell = exclude_table_list.head; cell; cell = cell->next)
+		{
+			/* Construct exclude table name placeholders to be used by PQexecParams */
+			appendStringInfo(&sql, "relid <> $%d::regclass", iparam + 1);
+			params[iparam++] = cell->val;
+			elog(INFO, "skipping table \"%s\"", cell->val);
+			if (cell->next)
+				appendStringInfoString(&sql, " AND ");
 		}
 		appendStringInfoString(&sql, ")");
 	}
@@ -2392,6 +2431,7 @@ pgut_help(bool details)
 	printf("  -Z, --no-analyze              don't analyze at end\n");
 	printf("  -k, --no-superuser-check      skip superuser checks in client\n");
 	printf("  -C, --exclude-extension       don't repack tables which belong to specific extension\n");
+	printf("  -X, --exclude-table           don't repack specific table\n");
 	printf("      --error-on-invalid-index  don't repack tables which belong to specific extension\n");
-	printf("      --switch-threshold    switch tables when that many tuples are left to catchup\n");
+	printf("      --switch-threshold    	switch tables when that many tuples are left to catchup\n");
 }

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -2471,7 +2471,7 @@ pgut_help(bool details)
 	printf("  -k, --no-superuser-check      skip superuser checks in client\n");
 	printf("  -C, --exclude-extension       don't repack tables which belong to specific extension\n");
 	printf("  -X, --exclude-table           don't repack specific table\n");
-	printf("  -Y, --exclude-parent-table    don't repack specific table and its inheritors\n");
+	printf("  -Y, --exclude-parent-table    don't repack specific parent table and its inheritors\n");
 	printf("      --error-on-invalid-index  don't repack tables which belong to specific extension\n");
 	printf("      --switch-threshold    	switch tables when that many tuples are left to catchup\n");
 }

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -123,6 +123,8 @@ Options:
   -Z, --no-analyze              don't analyze at end
   -k, --no-superuser-check      skip superuser checks in client
   -C, --exclude-extension       don't repack tables which belong to specific extension
+  -X, --exclude-table           don't repack specific table
+  -Y, --exclude-parent-table    don't repack specific table and its inheritors
       --error-on-invalid-index  don't repack when invalid index is found
       --switch-threshold        switch tables when that many tuples are left to catchup
 
@@ -226,6 +228,14 @@ Reorg Options
     Skip tables that belong to the specified extension(s). Some extensions
     may heavily depend on such tables at planning time etc.
 
+``-X``, ``--exclude-table``
+    Skip the specified table(s) only to repack. Multiple tables may be skipped by
+    writing multiple ``-X`` switches.
+
+``-Y``, ``--exclude-parent-table``
+    Skip the specified parent table(s) and its inheritors to repack. Multiple tables 
+    may be skipped by writing multiple ``-Y`` switches.
+
 ``--switch-threshold``
     Switch tables when that many tuples are left in log table.
     This setting can be used to avoid the inability to catchup with write-heavy tables.
@@ -325,6 +335,16 @@ Move all indexes of table ``foo`` to tablespace ``tbs``::
 Move the specified index to tablespace ``tbs``::
 
     $ pg_repack -d test --index idx --tablespace tbs
+
+Skip the specified table(s) to repack ``foo`` in schema ``schema`` in 
+the database ``test``::
+
+    $ pg_repack -d test -X schema.foo
+
+Skip the specified parent table(s) and its inheritors to repack ``foo`` in 
+schema ``schema`` in the database ``test``::
+
+    $ pg_repack -d test -Y schema.foo
 
 
 Diagnostics

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -124,7 +124,7 @@ Options:
   -k, --no-superuser-check      skip superuser checks in client
   -C, --exclude-extension       don't repack tables which belong to specific extension
   -X, --exclude-table           don't repack specific table
-  -Y, --exclude-parent-table    don't repack specific table and its inheritors
+  -Y, --exclude-parent-table    don't repack specific parent table and its inheritors
       --error-on-invalid-index  don't repack when invalid index is found
       --switch-threshold        switch tables when that many tuples are left to catchup
 


### PR DESCRIPTION
Added two options 

1. exclude-table (-X) : which can be used to skip a table to repack
2. exclude-parent-table (-Y) : which can be used to skip a parent table and its children

Both are added in documentation.