### PR TITLE
Move INSERT query of `repack.repack_trigger` to C

### DIFF
--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
    "name": "pg_repack",
    "abstract": "PostgreSQL module for data reorganization",
    "description": "Reorganize tables in PostgreSQL databases with minimal locks",
-   "version": "1.4.8",
+   "version": "1.4.9",
    "maintainer": [
        "Beena Emerson <memissemerson@gmail.com>",
        "Josh Kupershmidt <schmiddy@gmail.com>",

--- a/lib/pg_repack.sql.in
+++ b/lib/pg_repack.sql.in
@@ -26,7 +26,7 @@ LANGUAGE sql STABLE STRICT SET search_path to 'pg_catalog';
 
 CREATE FUNCTION repack.get_index_columns(oid, text) RETURNS text AS
 $$
-  SELECT coalesce(string_agg(quote_ident(attname), $2), '')
+  SELECT coalesce(string_agg(quote_literal(attname), $2), '')
     FROM pg_attribute,
          (SELECT indrelid,
                  indkey,
@@ -42,6 +42,37 @@ LANGUAGE sql STABLE STRICT;
 CREATE FUNCTION repack.get_order_by(oid, oid) RETURNS text AS
 'MODULE_PATHNAME', 'repack_get_order_by'
 LANGUAGE C STABLE STRICT;
+
+CREATE FUNCTION repack.create_log_table(oid) RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'CREATE TABLE repack.log_' || $1 ||
+            ' (id bigserial PRIMARY KEY,' ||
+            ' pk repack.pk_' || $1 || ',' ||
+            ' row ' || repack.oid2text($1) || ')';
+END
+$$
+LANGUAGE plpgsql;
+
+CREATE FUNCTION repack.create_table(oid, name) RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'CREATE TABLE repack.table_' || $1 ||
+            ' WITH (' || repack.get_storage_param($1) || ') ' ||
+            ' TABLESPACE ' || quote_ident($2) ||
+            ' AS SELECT ' || repack.get_columns_for_create_as($1) ||
+            ' FROM ONLY ' || repack.oid2text($1) || ' WITH NO DATA';
+END
+$$
+LANGUAGE plpgsql;
+
+CREATE FUNCTION repack.create_index_type(oid, oid) RETURNS void AS
+$$
+BEGIN
+    EXECUTE repack.get_create_index_type($1, 'repack.pk_' || $2);
+END
+$$
+LANGUAGE plpgsql;
 
 CREATE FUNCTION repack.get_create_index_type(oid, name) RETURNS text AS
 $$
@@ -66,10 +97,7 @@ $$
   SELECT 'CREATE TRIGGER repack_trigger' ||
          ' AFTER INSERT OR DELETE OR UPDATE ON ' || repack.oid2text($1) ||
          ' FOR EACH ROW EXECUTE PROCEDURE repack.repack_trigger(' ||
-         '''INSERT INTO repack.log_' || $1 || '(pk, row) VALUES(' ||
-         ' CASE WHEN $1 IS NULL THEN NULL ELSE (ROW($1.' ||
-         repack.get_index_columns($2, ', $1.') || ')::repack.pk_' ||
-         $1 || ') END, $2)'')';
+         repack.get_index_columns($2, ', ') || ')';
 $$
 LANGUAGE sql STABLE STRICT;
 
@@ -240,13 +268,12 @@ CREATE VIEW repack.tables AS
          N.nspname AS schemaname,
          PK.indexrelid AS pkid,
          CK.indexrelid AS ckid,
-         repack.get_create_index_type(PK.indexrelid, 'repack.pk_' || R.oid) AS create_pktype,
-         'CREATE TABLE repack.log_' || R.oid || ' (id bigserial PRIMARY KEY, pk repack.pk_' || R.oid || ', row ' || repack.oid2text(R.oid) || ')' AS create_log,
+         'SELECT repack.create_index_type(' || PK.indexrelid || ',' || R.oid || ')' AS create_pktype,
+         'SELECT repack.create_log_table(' || R.oid || ')' AS create_log,
          repack.get_create_trigger(R.oid, PK.indexrelid) AS create_trigger,
          repack.get_enable_trigger(R.oid) as enable_trigger,
-         'CREATE TABLE repack.table_' || R.oid || ' WITH (' || repack.get_storage_param(R.oid) || ') TABLESPACE '  AS create_table_1,
-         coalesce(quote_ident(S.spcname), 'pg_default') as tablespace_orig,
-         ' AS SELECT ' || repack.get_columns_for_create_as(R.oid) || ' FROM ONLY ' || repack.oid2text(R.oid) AS create_table_2,
+         'SELECT repack.create_table($1, $2)' AS create_table,
+         coalesce(S.spcname, S2.spcname) AS tablespace_orig,
          'INSERT INTO repack.table_' || R.oid || ' SELECT ' || repack.get_columns_for_create_as(R.oid) || ' FROM ONLY ' || repack.oid2text(R.oid) AS copy_data,
          repack.get_alter_col_storage(R.oid) AS alter_col_storage,
          repack.get_drop_columns(R.oid, 'repack.table_' || R.oid) AS drop_columns,
@@ -270,6 +297,10 @@ CREATE VIEW repack.tables AS
                 ON R.oid = CK.indrelid
          LEFT JOIN pg_namespace N ON N.oid = R.relnamespace
          LEFT JOIN pg_tablespace S ON S.oid = R.reltablespace
+         CROSS JOIN (SELECT S2.spcname
+             FROM pg_catalog.pg_database D
+             JOIN pg_catalog.pg_tablespace S2 ON S2.oid = D.dattablespace
+             WHERE D.datname = current_database()) S2
    WHERE R.relkind = 'r'
      AND R.relpersistence = 'p'
      AND N.nspname NOT IN ('pg_catalog', 'information_schema')
@@ -281,7 +312,8 @@ LANGUAGE C STABLE;
 
 CREATE FUNCTION repack.repack_trigger() RETURNS trigger AS
 'MODULE_PATHNAME', 'repack_trigger'
-LANGUAGE C VOLATILE STRICT SECURITY DEFINER;
+LANGUAGE C VOLATILE STRICT SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp;
 
 CREATE FUNCTION repack.conflicted_triggers(oid) RETURNS SETOF name AS
 $$

--- a/lib/pg_repack.sql.in
+++ b/lib/pg_repack.sql.in
@@ -24,9 +24,14 @@ $$
 $$
 LANGUAGE sql STABLE STRICT SET search_path to 'pg_catalog';
 
-CREATE FUNCTION repack.get_index_columns(oid, text) RETURNS text AS
+-- Get a comma-separated column list of the index.
+--
+-- Columns are quoted as literals because they are going to be passed to
+-- the `repack_trigger` function as text arguments. `repack_trigger` will quote
+-- them as identifiers later.
+CREATE FUNCTION repack.get_index_columns(oid) RETURNS text AS
 $$
-  SELECT coalesce(string_agg(quote_literal(attname), $2), '')
+  SELECT coalesce(string_agg(quote_literal(attname), ', '), '')
     FROM pg_attribute,
          (SELECT indrelid,
                  indkey,
@@ -97,7 +102,7 @@ $$
   SELECT 'CREATE TRIGGER repack_trigger' ||
          ' AFTER INSERT OR DELETE OR UPDATE ON ' || repack.oid2text($1) ||
          ' FOR EACH ROW EXECUTE PROCEDURE repack.repack_trigger(' ||
-         repack.get_index_columns($2, ', ') || ')';
+         repack.get_index_columns($2) || ')';
 $$
 LANGUAGE sql STABLE STRICT;
 

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -17,7 +17,7 @@ INTVERSION := $(shell echo $$(($$(echo $(VERSION).0 | sed 's/\([[:digit:]]\{1,\}
 # Test suite
 #
 
-REGRESS := init-extension repack-setup repack-run error-on-invalid-idx after-schema repack-check nosuper tablespace get_order_by
+REGRESS := init-extension repack-setup repack-run error-on-invalid-idx after-schema repack-check nosuper tablespace get_order_by trigger
 
 USE_PGXS = 1	# use pgxs if not in contrib directory
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/regress/expected/tablespace.out
+++ b/regress/expected/tablespace.out
@@ -66,6 +66,19 @@ WHERE indrelid = 'testts1'::regclass ORDER BY relname;
  CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) WITH (fillfactor='80') TABLESPACE foo
 (3 rows)
 
+-- Test that a tablespace is quoted as an identifier
+SELECT regexp_replace(
+    repack.repack_indexdef(indexrelid, 'testts1'::regclass, 'foo bar', false),
+    '_[0-9]+', '_OID', 'g')
+FROM pg_index i join pg_class c ON c.oid = indexrelid
+WHERE indrelid = 'testts1'::regclass ORDER BY relname;
+                                             regexp_replace                                              
+---------------------------------------------------------------------------------------------------------
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "foo bar" WHERE (id > 0)
+ CREATE UNIQUE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "foo bar"
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) WITH (fillfactor='80') TABLESPACE "foo bar"
+(3 rows)
+
 -- can move the tablespace from default
 \! pg_repack --dbname=contrib_regression --no-order --table=testts1 --tablespace testts
 INFO: repacking table "public.testts1"

--- a/regress/expected/tablespace_1.out
+++ b/regress/expected/tablespace_1.out
@@ -66,6 +66,19 @@ WHERE indrelid = 'testts1'::regclass ORDER BY relname;
  CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) WITH (fillfactor='80') TABLESPACE foo
 (3 rows)
 
+-- Test that a tablespace is quoted as an identifier
+SELECT regexp_replace(
+    repack.repack_indexdef(indexrelid, 'testts1'::regclass, 'foo bar', false),
+    '_[0-9]+', '_OID', 'g')
+FROM pg_index i join pg_class c ON c.oid = indexrelid
+WHERE indrelid = 'testts1'::regclass ORDER BY relname;
+                                             regexp_replace                                              
+---------------------------------------------------------------------------------------------------------
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "foo bar" WHERE (id > 0)
+ CREATE UNIQUE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "foo bar"
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) WITH (fillfactor='80') TABLESPACE "foo bar"
+(3 rows)
+
 -- can move the tablespace from default
 \! pg_repack --dbname=contrib_regression --no-order --table=testts1 --tablespace testts
 INFO: repacking table "public.testts1"

--- a/regress/expected/tablespace_2.out
+++ b/regress/expected/tablespace_2.out
@@ -66,6 +66,19 @@ WHERE indrelid = 'testts1'::regclass ORDER BY relname;
  CREATE INDEX CONCURRENTLY index_OID ON public.testts1 USING btree (id) WITH (fillfactor='80') TABLESPACE foo
 (3 rows)
 
+-- Test that a tablespace is quoted as an identifier
+SELECT regexp_replace(
+    repack.repack_indexdef(indexrelid, 'testts1'::regclass, 'foo bar', false),
+    '_[0-9]+', '_OID', 'g')
+FROM pg_index i join pg_class c ON c.oid = indexrelid
+WHERE indrelid = 'testts1'::regclass ORDER BY relname;
+                                             regexp_replace                                              
+---------------------------------------------------------------------------------------------------------
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "foo bar" WHERE (id > 0)
+ CREATE UNIQUE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "foo bar"
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) WITH (fillfactor='80') TABLESPACE "foo bar"
+(3 rows)
+
 -- can move the tablespace from default
 \! pg_repack --dbname=contrib_regression --no-order --table=testts1 --tablespace testts
 INFO: repacking table "public.testts1"

--- a/regress/expected/tablespace_3.out
+++ b/regress/expected/tablespace_3.out
@@ -66,6 +66,19 @@ WHERE indrelid = 'testts1'::regclass ORDER BY relname;
  CREATE INDEX CONCURRENTLY index_OID ON testts1 USING btree (id) WITH (fillfactor=80) TABLESPACE foo
 (3 rows)
 
+-- Test that a tablespace is quoted as an identifier
+SELECT regexp_replace(
+    repack.repack_indexdef(indexrelid, 'testts1'::regclass, 'foo bar', false),
+    '_[0-9]+', '_OID', 'g')
+FROM pg_index i join pg_class c ON c.oid = indexrelid
+WHERE indrelid = 'testts1'::regclass ORDER BY relname;
+                                             regexp_replace                                              
+---------------------------------------------------------------------------------------------------------
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "foo bar" WHERE (id > 0)
+ CREATE UNIQUE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "foo bar"
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) WITH (fillfactor='80') TABLESPACE "foo bar"
+(3 rows)
+
 -- can move the tablespace from default
 \! pg_repack --dbname=contrib_regression --no-order --table=testts1 --tablespace testts
 INFO: repacking table "public.testts1"

--- a/regress/expected/tablespace_4.out
+++ b/regress/expected/tablespace_4.out
@@ -66,6 +66,19 @@ WHERE indrelid = 'testts1'::regclass ORDER BY relname;
  CREATE INDEX CONCURRENTLY index_OID ON public.testts1 USING btree (id) WITH (fillfactor='80') TABLESPACE foo
 (3 rows)
 
+-- Test that a tablespace is quoted as an identifier
+SELECT regexp_replace(
+    repack.repack_indexdef(indexrelid, 'testts1'::regclass, 'foo bar', false),
+    '_[0-9]+', '_OID', 'g')
+FROM pg_index i join pg_class c ON c.oid = indexrelid
+WHERE indrelid = 'testts1'::regclass ORDER BY relname;
+                                             regexp_replace                                              
+---------------------------------------------------------------------------------------------------------
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "foo bar" WHERE (id > 0)
+ CREATE UNIQUE INDEX index_OID ON repack.table_OID USING btree (id) TABLESPACE "foo bar"
+ CREATE INDEX index_OID ON repack.table_OID USING btree (id) WITH (fillfactor='80') TABLESPACE "foo bar"
+(3 rows)
+
 -- can move the tablespace from default
 \! pg_repack --dbname=contrib_regression --no-order --table=testts1 --tablespace testts
 INFO: repacking table "public.testts1"

--- a/regress/expected/trigger.out
+++ b/regress/expected/trigger.out
@@ -1,0 +1,28 @@
+--
+-- repack.repack_trigger tests
+--
+CREATE TABLE trigger_t1 (a int, b int, primary key (a, b));
+CREATE INDEX trigger_t1_idx ON trigger_t1 (a, b);
+SELECT create_trigger FROM repack.tables WHERE relname = 'public.trigger_t1';
+                                                                   create_trigger                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ CREATE TRIGGER repack_trigger AFTER INSERT OR DELETE OR UPDATE ON public.trigger_t1 FOR EACH ROW EXECUTE PROCEDURE repack.repack_trigger('a', 'b')
+(1 row)
+
+SELECT oid AS t1_oid FROM pg_catalog.pg_class WHERE relname = 'trigger_t1'
+\gset
+CREATE TYPE repack.pk_:t1_oid AS (a integer, b integer);
+CREATE TABLE repack.log_:t1_oid (id bigserial PRIMARY KEY, pk repack.pk_:t1_oid, row public.trigger_t1);
+CREATE TRIGGER repack_trigger AFTER INSERT OR DELETE OR UPDATE ON trigger_t1
+    FOR EACH ROW EXECUTE PROCEDURE repack.repack_trigger('a', 'b');
+INSERT INTO trigger_t1 VALUES (111, 222);
+UPDATE trigger_t1 SET a=333, b=444 WHERE a = 111;
+DELETE FROM trigger_t1 WHERE a = 333;
+SELECT * FROM repack.log_:t1_oid;
+ id |    pk     |    row    
+----+-----------+-----------
+  1 |           | (111,222)
+  2 | (111,222) | (333,444)
+  3 | (333,444) | 
+(3 rows)
+

--- a/regress/sql/tablespace.sql
+++ b/regress/sql/tablespace.sql
@@ -41,6 +41,13 @@ SELECT regexp_replace(
 FROM pg_index i join pg_class c ON c.oid = indexrelid
 WHERE indrelid = 'testts1'::regclass ORDER BY relname;
 
+-- Test that a tablespace is quoted as an identifier
+SELECT regexp_replace(
+    repack.repack_indexdef(indexrelid, 'testts1'::regclass, 'foo bar', false),
+    '_[0-9]+', '_OID', 'g')
+FROM pg_index i join pg_class c ON c.oid = indexrelid
+WHERE indrelid = 'testts1'::regclass ORDER BY relname;
+
 -- can move the tablespace from default
 \! pg_repack --dbname=contrib_regression --no-order --table=testts1 --tablespace testts
 

--- a/regress/sql/trigger.sql
+++ b/regress/sql/trigger.sql
@@ -1,0 +1,21 @@
+--
+-- repack.repack_trigger tests
+--
+
+CREATE TABLE trigger_t1 (a int, b int, primary key (a, b));
+CREATE INDEX trigger_t1_idx ON trigger_t1 (a, b);
+
+SELECT create_trigger FROM repack.tables WHERE relname = 'public.trigger_t1';
+
+SELECT oid AS t1_oid FROM pg_catalog.pg_class WHERE relname = 'trigger_t1'
+\gset
+
+CREATE TYPE repack.pk_:t1_oid AS (a integer, b integer);
+CREATE TABLE repack.log_:t1_oid (id bigserial PRIMARY KEY, pk repack.pk_:t1_oid, row public.trigger_t1);
+CREATE TRIGGER repack_trigger AFTER INSERT OR DELETE OR UPDATE ON trigger_t1
+    FOR EACH ROW EXECUTE PROCEDURE repack.repack_trigger('a', 'b');
+
+INSERT INTO trigger_t1 VALUES (111, 222);
+UPDATE trigger_t1 SET a=333, b=444 WHERE a = 111;
+DELETE FROM trigger_t1 WHERE a = 333;
+SELECT * FROM repack.log_:t1_oid;


### PR DESCRIPTION
Making INSERT query in C prevents SQL injections, which are possible if an INSERT query is passed as an argument.

Here is an example with "old" `repack.repack_trigger`:

```
CREATE EXTENSION pg_repack;
CREATE TABLE public.t1 (a int);
CREATE TABLE public.t2 (b varchar);
INSERT INTO public.t2 VALUES (current_user);
CREATE TRIGGER repack_trigger AFTER INSERT ON public.t1
FOR EACH ROW EXECUTE PROCEDURE repack.repack_trigger('INSERT INTO public.t2 VALUES (current_user)');
INSERT INTO public.t1 VALUES (1);
SELECT b FROM public.t2;
  b 
----------
 bob
 postgres 
```

It is possible to move `repack.get_index_columns` to C too. But list of columns is passed as an argument as for now for the sake of simplicity.

Additionally this commit adds funtions:
- repack.create_index_type
- repack.create_log_table
- repack.create_table

Another change is that `tablespace_orig` considers default tablespace of a database (issues https://github.com/reorg/pg_repack/issues/363, https://github.com/reorg/pg_repack/issues/305)