### PR TITLE
Add PostgrerSQL16 into supported versions

### DIFF
--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -40,7 +40,7 @@ Requirements
 ------------
 
 PostgreSQL versions
-    PostgreSQL 9.4, 9.5, 9.6, 10, 11, 12, 13, 14, 15
+    PostgreSQL 9.4, 9.5, 9.6, 10, 11, 12, 13, 14, 15, 16
 
 Disks
     Performing a full-table repack requires free disk space about twice as

--- a/doc/pg_repack_jp.rst
+++ b/doc/pg_repack_jp.rst
@@ -62,7 +62,7 @@ pg_repackでは再編成する方法として次のものが選択できます�
   ------------
   
   PostgreSQL versions
-      PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 10
+      PostgreSQL 9.4, 9.5, 9.6, 10, 11, 12, 13, 14, 15, 16
   
   Disks
       Performing a full-table repack requires free disk space about twice as
@@ -75,7 +75,7 @@ pg_repackでは再編成する方法として次のものが選択できます�
 ---------
 
 PostgreSQL バージョン
-    PostgreSQL 9.1, 9.2, 9.3, 9.4, 9.5, 9.6
+    PostgreSQL 9.4, 9.5, 9.6, 10, 11, 12, 13, 14, 15, 16
 
 ディスク
     テーブル全体の再編成を行うには、対象となるテーブルと付属するインデックスのおよそ2倍のサイズのディスク空き容量が必要です。例えば、テーブルとインデックスを合わせたサイズが1GBの場合、2GBのディスク領域が必要となります。


### PR DESCRIPTION
Add PostgrerSQL16 into supported versions into `docs/pg_repack.rst` and `docs/pg_repack_jp.rst`.
Tests were added by https://github.com/reorg/pg_repack/pull/364.

We probably could delete oldest PostgreSQL versions which are not listed in https://github.com/reorg/pg_repack/blob/6263dd5e7fcb2890c68b4237591628c4ad08259d/.github/workflows/regression.yml#L10-L16