### PR TITLE
Fix wrong OID format type in repack_trigger

### DIFF
--- a/lib/repack.c
+++ b/lib/repack.c
@@ -206,12 +206,12 @@ repack_trigger(PG_FUNCTION_ARGS)
 
 	/* prepare INSERT query */
 	sql = makeStringInfo();
-	appendStringInfo(sql, "INSERT INTO repack.log_%d(pk, row) "
+	appendStringInfo(sql, "INSERT INTO repack.log_%u(pk, row) "
 		"VALUES(CASE WHEN $1 IS NULL THEN NULL ELSE (ROW(", relid);
 	appendStringInfo(sql, "$1.%s", quote_identifier(trigdata->tg_trigger->tgargs[0]));
 	for (int i = 1; i < trigdata->tg_trigger->tgnargs; ++i)
 		appendStringInfo(sql, ", $1.%s", quote_identifier(trigdata->tg_trigger->tgargs[i]));
-	appendStringInfo(sql, ")::repack.pk_%d) END, $2)", relid);
+	appendStringInfo(sql, ")::repack.pk_%u) END, $2)", relid);
 
 	/* execute the INSERT query */
 	execute_with_args(SPI_OK_INSERT, sql->data, 2, argtypes, values, nulls);


### PR DESCRIPTION
Table OID should be unsigned four-byte integer, therefore formatting with %d is wrong. %u should be used as in other places.

It's surprising that we haven't received such error messages before. But such a query is definitely wrong: 
```
INSERT INTO repack.log_-907750756(pk, row) ...
```

I have no idea how to add a test with large OID.