### PR TITLE
Fix swap of relfrozenxid, relfrozenxid and relallvisible

### DIFF
--- a/lib/repack.c
+++ b/lib/repack.c
@@ -1189,7 +1189,6 @@ swap_heap_or_index_files(Oid r1, Oid r2)
 	Form_pg_class relform1,
 				relform2;
 	Oid			swaptemp;
-	TransactionId swaptempxid;
 	CatalogIndexState indstate;
 
 	/* We need writable copies of both pg_class tuples. */
@@ -1231,13 +1230,16 @@ swap_heap_or_index_files(Oid r1, Oid r2)
 	 */
 	if (relform1->relkind != RELKIND_INDEX)
 	{
-		swaptempxid = relform1->relfrozenxid;
+		TransactionId frozenxid;
+		MultiXactId	minmxid;
+	
+		frozenxid = relform1->relfrozenxid;
 		relform1->relfrozenxid = relform2->relfrozenxid;
-		relform2->relfrozenxid = swaptempxid;
+		relform2->relfrozenxid = frozenxid;
 
-		swaptempxid = relform1->relminmxid;
+		minmxid = relform1->relminmxid;
 		relform1->relminmxid = relform2->relminmxid;
-		relform2->relminmxid = swaptempxid;
+		relform2->relminmxid = minmxid;
 	}
 
 	/* swap size statistics too, since new rel has freshly-updated stats */

--- a/lib/repack.c
+++ b/lib/repack.c
@@ -1189,6 +1189,7 @@ swap_heap_or_index_files(Oid r1, Oid r2)
 	Form_pg_class relform1,
 				relform2;
 	Oid			swaptemp;
+	TransactionId swaptempxid;
 	CatalogIndexState indstate;
 
 	/* We need writable copies of both pg_class tuples. */
@@ -1225,15 +1226,18 @@ swap_heap_or_index_files(Oid r1, Oid r2)
 	relform1->reltoastrelid = relform2->reltoastrelid;
 	relform2->reltoastrelid = swaptemp;
 
-	/* set rel1's frozen Xid to larger one */
-	if (TransactionIdIsNormal(relform1->relfrozenxid))
-	{
-		if (TransactionIdFollows(relform1->relfrozenxid,
-								 relform2->relfrozenxid))
-			relform1->relfrozenxid = relform2->relfrozenxid;
-		else
-			relform2->relfrozenxid = relform1->relfrozenxid;
-	}
+	/*
+	 * Swap relfrozenxid and relminmxid, as they must be consistent with the data
+	 */
+	swaptemp = relform1->relfrozenxid;
+	relform1->relfrozenxid = relform2->relfrozenxid;
+	relform2->relfrozenxid = swaptempxid;
+
+#if PG_VERSION_NUM >= 90300
+	swaptemp = relform1->relminmxid;
+	relform1->relminmxid = relform2->relminmxid;
+	relform2->relminmxid = swaptempxid;
+#endif
 
 	/* swap size statistics too, since new rel has freshly-updated stats */
 	{
@@ -1247,6 +1251,12 @@ swap_heap_or_index_files(Oid r1, Oid r2)
 		swap_tuples = relform1->reltuples;
 		relform1->reltuples = relform2->reltuples;
 		relform2->reltuples = swap_tuples;
+
+#if PG_VERSION_NUM >= 90200
+		swap_pages = relform1->relallvisible;
+		relform1->relallvisible = relform2->relallvisible;
+		relform2->relallvisible = swap_pages;
+#endif
 	}
 
 	indstate = CatalogOpenIndexes(relRelation);


### PR DESCRIPTION
This PR is follow up of https://github.com/reorg/pg_repack/pull/157.

- I fixed the typo: https://github.com/reorg/pg_repack/pull/157#issuecomment-1519195513
- I removed `PG_VERSION_NUM >= 90300` check since we don't support such old versions anyway
- I added check `relform1->relkind != RELKIND_INDEX` since `relfrozenxid` and `relminmxid` is non-zero only for tables

I think we still need to check the current state of `swap_relation_files` (https://github.com/postgres/postgres/blob/ae69c4fcf1337af399a788ab8d96af540bd1cd8e/src/backend/commands/cluster.c?plain=1#L1055). It has a few differences with the code of `repack.c`. We don't need to copy all the code, since not all features are supported by pg_repack. For example we don't repack system tables, mapped tables. And maybe we don't need to support `swap_toast_by_content`?

I'll try to come up with a PR to try to sync the code.