### PR TITLE
Repack all tables smallest to largest

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -871,8 +871,13 @@ repack_one_database(const char *orderby, char *errbuf, size_t errsize)
 		appendStringInfoString(&sql, ")");
 	}
 
-	/* Ensure the regression tests get a consistent ordering of tables */
-	appendStringInfoString(&sql, " ORDER BY t.relname, t.schemaname");
+	/* Ensure the regression tests get a consistent ordering of tables
+	 * Otherwise repack small objects first to free space on disk
+	 */
+	if (getenv("MAKELEVEL"))
+		appendStringInfoString(&sql, " ORDER BY t.relname, t.schemaname");
+	else
+		appendStringInfoString(&sql, " ORDER BY pg_relation_size(t.relid)");
 
 	/* double check the parameters array is sane */
 	if (iparam != num_params)


### PR DESCRIPTION
Free up space early to improve the overhead for repacking large tables. Preserve ordering by `relname, schemaname` for tests if `MAKELEVEL` is defined.

The following graph shows the size of `base` as reported by du(1) for the duration of `pg_repack -j2 -a`. By repacking small tables first, very little free may be required.

![pg_repack_sort](https://github.com/user-attachments/assets/ce28cd4a-b476-40e6-b598-14603a22630b)
