### PR TITLE
Remove compliation warning of unitialized value

### DIFF
--- a/lib/pgut/pgut-spi.c
+++ b/lib/pgut/pgut-spi.c
@@ -82,7 +82,7 @@ execute_with_args(int expected, const char *src, int nargs, Oid argtypes[], Datu
 {
 	int		ret;
 	int		i;
-	char	c_nulls[FUNC_MAX_ARGS];
+	char	c_nulls[FUNC_MAX_ARGS] = {0};
 
     	memset(c_nulls, 0, sizeof(c_nulls));
 


### PR DESCRIPTION
We have a fork postgres that also contains pg_repack and get warning in gcc 12.2.1 that stop build (we have set option "threat warnings as errors"), hope it will be usefull in community version