### PR TITLE
fix LockHeldByMe compilation error against pg17

### DIFF
--- a/lib/repack.c
+++ b/lib/repack.c
@@ -905,7 +905,12 @@ repack_swap(PG_FUNCTION_ARGS)
 	 * Sanity check if both relations are locked in access exclusive mode
 	 * before swapping these files.
 	 */
-#if PG_VERSION_NUM >= 120000
+#if PG_VERSION_NUM >= 170000
+	if (! CheckRelationOidLockedByMe(oid, AccessExclusiveLock, true))
+		elog(ERROR, "must hold access exclusive lock on table \"%s\"", relname);
+	if (! CheckRelationOidLockedByMe(oid2, AccessExclusiveLock, true))
+		elog(ERROR, "must hold access exclusive lock on table \"table_%u\"", oid);
+#elif PG_VERSION_NUM >= 120000
 	{
 		LOCKTAG	tag;
 


### PR DESCRIPTION
commit [0cecc908e9749101b5e93ba58d76a62c9f226f9e](https://github.com/postgres/postgres/commit/0cecc908e9749101b5e93ba58d76a62c9f226f9e) in postgresql changed the signature of the LockHeldByMe function, which caused the pg_repack build to fail.

Actually, the orstronger argument is not important for us, since we need the strictest AccessExclusiveLock lock. But I can simplify the code a little by using a more appropriate new CheckRelationOidLockedByMe function.