### PR TITLE
Issue #422: Make --error-on-invalid-index the default behavior

### DIFF
--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -109,40 +109,41 @@ Usage
 The following options can be specified in ``OPTIONS``.
 
 Options:
-  -a, --all                     repack all databases
-  -t, --table=TABLE             repack specific table only
-  -I, --parent-table=TABLE      repack specific parent table and its inheritors
-  -c, --schema=SCHEMA           repack tables in specific schema only
-  -s, --tablespace=TBLSPC       move repacked tables to a new tablespace
-  -S, --moveidx                 move repacked indexes to *TBLSPC* too
-  -o, --order-by=COLUMNS        order by columns instead of cluster keys
-  -n, --no-order                do vacuum full instead of cluster
-  -N, --dry-run                 print what would have been repacked and exit
-  -j, --jobs=NUM                Use this many parallel jobs for each table
-  -i, --index=INDEX             move only the specified index
-  -x, --only-indexes            move only indexes of the specified table
-  -T, --wait-timeout=SECS       timeout to cancel other backends on conflict
-  -D, --no-kill-backend         don't kill other backends when timed out
-  -Z, --no-analyze              don't analyze at end
-  -k, --no-superuser-check      skip superuser checks in client
-  -C, --exclude-extension       don't repack tables which belong to specific extension
-      --error-on-invalid-index  don't repack when invalid index is found
-      --apply-count             number of tuples to apply in one trasaction during replay
-      --switch-threshold        switch tables when that many tuples are left to catchup
+  -a, --all                          repack all databases
+  -t, --table=TABLE                  repack specific table only
+  -I, --parent-table=TABLE           repack specific parent table and its inheritors
+  -c, --schema=SCHEMA                repack tables in specific schema only
+  -s, --tablespace=TBLSPC            move repacked tables to a new tablespace
+  -S, --moveidx                      move repacked indexes to *TBLSPC* too
+  -o, --order-by=COLUMNS             order by columns instead of cluster keys
+  -n, --no-order                     do vacuum full instead of cluster
+  -N, --dry-run                      print what would have been repacked and exit
+  -j, --jobs=NUM                     Use this many parallel jobs for each table
+  -i, --index=INDEX                  move only the specified index
+  -x, --only-indexes                 move only indexes of the specified table
+  -T, --wait-timeout=SECS            timeout to cancel other backends on conflict
+  -D, --no-kill-backend              don't kill other backends when timed out
+  -Z, --no-analyze                   don't analyze at end
+  -k, --no-superuser-check           skip superuser checks in client
+  -C, --exclude-extension            don't repack tables which belong to specific extension
+      --no-error-on-invalid-index    repack even though invalid index is found
+      --error-on-invalid-index       don't repack when invalid index is found, deprecated, as this is the default behavior now
+      --apply-count                  number of tuples to apply in one trasaction during replay
+      --switch-threshold             switch tables when that many tuples are left to catchup
 
 Connection options:
-  -d, --dbname=DBNAME           database to connect
-  -h, --host=HOSTNAME           database server host or socket directory
-  -p, --port=PORT               database server port
-  -U, --username=USERNAME       user name to connect as
-  -w, --no-password             never prompt for password
-  -W, --password                force password prompt
+  -d, --dbname=DBNAME                database to connect
+  -h, --host=HOSTNAME                database server host or socket directory
+  -p, --port=PORT                    database server port
+  -U, --username=USERNAME            user name to connect as
+  -w, --no-password                  never prompt for password
+  -W, --password                     force password prompt
 
 Generic options:
-  -e, --echo                    echo queries
-  -E, --elevel=LEVEL            set output message level
-  --help                        show this help, then exit
-  --version                     output version information, then exit
+  -e, --echo                         echo queries
+  -E, --elevel=LEVEL                 set output message level
+  --help                             show this help, then exit
+  --version                          output version information, then exit
 
 
 Reorg Options

--- a/doc/pg_repack_jp.rst
+++ b/doc/pg_repack_jp.rst
@@ -197,39 +197,40 @@ pg_repackもしくはpg_reorgの古いバージョンからのアップグレー
   The following options can be specified in ``OPTIONS``.
   
   Options:
-    -a, --all                     repack all databases
-    -t, --table=TABLE             repack specific table only
-    -I, --parent-table=TABLE      repack specific parent table and its inheritors
-    -c, --schema=SCHEMA           repack tables in specific schema only
-    -s, --tablespace=TBLSPC       move repacked tables to a new tablespace
-    -S, --moveidx                 move repacked indexes to *TBLSPC* too
-    -o, --order-by=COLUMNS        order by columns instead of cluster keys
-    -n, --no-order                do vacuum full instead of cluster
-    -N, --dry-run                 print what would have been repacked and exit
-    -j, --jobs=NUM                Use this many parallel jobs for each table
-    -i, --index=INDEX             move only the specified index
-    -x, --only-indexes            move only indexes of the specified table
-    -T, --wait-timeout=SECS       timeout to cancel other backends on conflict
-    -D, --no-kill-backend         don't kill other backends when timed out
-    -Z, --no-analyze              don't analyze at end
-    -k, --no-superuser-check      skip superuser checks in client
-    -C, --exclude-extension       don't repack tables which belong to specific extension
-        --error-on-invalid-index  don't repack when invalid index is found
-        --switch-threshold        switch tables when that many tuples are left to catchup
+    -a, --all                          repack all databases
+    -t, --table=TABLE                  repack specific table only
+    -I, --parent-table=TABLE           repack specific parent table and its inheritors
+    -c, --schema=SCHEMA                repack tables in specific schema only
+    -s, --tablespace=TBLSPC            move repacked tables to a new tablespace
+    -S, --moveidx                      move repacked indexes to *TBLSPC* too
+    -o, --order-by=COLUMNS             order by columns instead of cluster keys
+    -n, --no-order                     do vacuum full instead of cluster
+    -N, --dry-run                      print what would have been repacked and exit
+    -j, --jobs=NUM                     Use this many parallel jobs for each table
+    -i, --index=INDEX                  move only the specified index
+    -x, --only-indexes                 move only indexes of the specified table
+    -T, --wait-timeout=SECS            timeout to cancel other backends on conflict
+    -D, --no-kill-backend              don't kill other backends when timed out
+    -Z, --no-analyze                   don't analyze at end
+    -k, --no-superuser-check           skip superuser checks in client
+    -C, --exclude-extension            don't repack tables which belong to specific extension
+        --no-error-on-invalid-index    repack even though invalid index is found
+        --error-on-invalid-index       don't repack when invalid index is found, deprecated, as this is the default behavior now
+        --switch-threshold             switch tables when that many tuples are left to catchup
   
   Connection options:
-    -d, --dbname=DBNAME           database to connect
-    -h, --host=HOSTNAME           database server host or socket directory
-    -p, --port=PORT               database server port
-    -U, --username=USERNAME       user name to connect as
-    -w, --no-password             never prompt for password
-    -W, --password                force password prompt
+    -d, --dbname=DBNAME                database to connect
+    -h, --host=HOSTNAME                database server host or socket directory
+    -p, --port=PORT                    database server port
+    -U, --username=USERNAME            user name to connect as
+    -w, --no-password                  never prompt for password
+    -W, --password                     force password prompt
   
   Generic options:
-    -e, --echo                    echo queries
-    -E, --elevel=LEVEL            set output message level
-    --help                        show this help, then exit
-    --version                     output version information, then exit
+    -e, --echo                         echo queries
+    -E, --elevel=LEVEL                 set output message level
+    --help                             show this help, then exit
+    --version                          output version information, then exit
 
 利用方法
 ---------

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -17,7 +17,7 @@ INTVERSION := $(shell echo $$(($$(echo $(VERSION).0 | sed 's/\([[:digit:]]\{1,\}
 # Test suite
 #
 
-REGRESS := init-extension repack-setup repack-run error-on-invalid-idx after-schema repack-check nosuper tablespace get_order_by trigger
+REGRESS := init-extension repack-setup repack-run error-on-invalid-idx no-error-on-invalid-idx after-schema repack-check nosuper tablespace get_order_by trigger
 
 USE_PGXS = 1	# use pgxs if not in contrib directory
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/regress/expected/no-error-on-invalid-idx.out
+++ b/regress/expected/no-error-on-invalid-idx.out
@@ -1,17 +1,18 @@
 --
 -- do repack
 --
-\! pg_repack --dbname=contrib_regression --table=tbl_cluster
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --no-error-on-invalid-index
 INFO: repacking table "public.tbl_cluster"
-\! pg_repack --dbname=contrib_regression --table=tbl_badindex
+\! pg_repack --dbname=contrib_regression --table=tbl_badindex --no-error-on-invalid-index
 INFO: repacking table "public.tbl_badindex"
-WARNING: Invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
-\! pg_repack --dbname=contrib_regression
+WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
+\! pg_repack --dbname=contrib_regression --no-error-on-invalid-index
 INFO: repacking table "public.tbl_badindex"
-WARNING: Invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
+WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
 INFO: repacking table "public.tbl_cluster"
 INFO: repacking table "public.tbl_gistkey"
 INFO: repacking table "public.tbl_idxopts"
+INFO: repacking table "public.tbl_incl_pkey"
 INFO: repacking table "public.tbl_only_pkey"
 INFO: repacking table "public.tbl_order"
 INFO: repacking table "public.tbl_storage_plain"

--- a/regress/expected/no-error-on-invalid-idx_1.out
+++ b/regress/expected/no-error-on-invalid-idx_1.out
@@ -1,14 +1,14 @@
 --
 -- do repack
 --
-\! pg_repack --dbname=contrib_regression --table=tbl_cluster
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --no-error-on-invalid-index
 INFO: repacking table "public.tbl_cluster"
-\! pg_repack --dbname=contrib_regression --table=tbl_badindex
+\! pg_repack --dbname=contrib_regression --table=tbl_badindex --no-error-on-invalid-index
 INFO: repacking table "public.tbl_badindex"
-WARNING: Invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
-\! pg_repack --dbname=contrib_regression
+WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
+\! pg_repack --dbname=contrib_regression --no-error-on-invalid-index
 INFO: repacking table "public.tbl_badindex"
-WARNING: Invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
+WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
 INFO: repacking table "public.tbl_cluster"
 INFO: repacking table "public.tbl_gistkey"
 INFO: repacking table "public.tbl_idxopts"

--- a/regress/expected/repack-run.out
+++ b/regress/expected/repack-run.out
@@ -5,10 +5,10 @@
 INFO: repacking table "public.tbl_cluster"
 \! pg_repack --dbname=contrib_regression --table=tbl_badindex
 INFO: repacking table "public.tbl_badindex"
-WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
+WARNING: Invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
 \! pg_repack --dbname=contrib_regression
 INFO: repacking table "public.tbl_badindex"
-WARNING: skipping invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
+WARNING: Invalid index: CREATE UNIQUE INDEX idx_badindex_n ON public.tbl_badindex USING btree (n)
 INFO: repacking table "public.tbl_cluster"
 INFO: repacking table "public.tbl_gistkey"
 INFO: repacking table "public.tbl_idxopts"

--- a/regress/sql/no-error-on-invalid-idx.sql
+++ b/regress/sql/no-error-on-invalid-idx.sql
@@ -1,0 +1,7 @@
+--
+-- do repack
+--
+
+\! pg_repack --dbname=contrib_regression --table=tbl_cluster --no-error-on-invalid-index
+\! pg_repack --dbname=contrib_regression --table=tbl_badindex --no-error-on-invalid-index
+\! pg_repack --dbname=contrib_regression --no-error-on-invalid-index


### PR DESCRIPTION
Skipping repacking the invalid indexes could lead to corrupting the invalid indexes. In some rare cases, this might cause inserts to tables to fail as changes to a table continuously be applied to invalid indexes on it and updates to corrupted invalid indexes potentially might fail by the checks done during insertion. Therefore, by default do not repack a table with invalid indexes. Repack only user explicitly specifies --no-error-on-invalid-index.