### PR TITLE
postgresql 18

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -30,6 +30,10 @@ jobs:
       - name: Install build-dependencies
         run: apt-get install -y liblz4-dev libreadline-dev zlib1g-dev libzstd-dev
 
+      - name: Install additional build-dependencies for 18+
+        if: ${{ matrix.pg >= 18 }}
+        run: apt-get install -y libcurl4-openssl-dev
+
       - name: Check out the repo
         uses: actions/checkout@v3
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -7,6 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         pg:
+          - 18
           - 17
           - 16
           - 15


### PR DESCRIPTION
[Feature freeze day](https://www.postgresql.org/message-id/Z_U0fUvVkXOZmRVV%40momjian.us)! It looks like nothing needs to be changed this year to support the new release. Add pg18 to the tests.