### PR TITLE
Issue #420: Acquire SHARE UPDATE EXCLUSIVE by conn2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 *.so
 *.bc
+*.dylib
 regress/regression.diffs
 regress/regression.out
 regress/results/

--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -1412,12 +1412,12 @@ repack_one_table(repack_table *table, const char *orderby)
 
 	/*
 	 * Not using lock_access_share() here since we know that
-	 * it's not possible to obtain the ACCESS SHARE lock right now
+	 * it's not possible to obtain the SHARE UPDATE EXCLUSIVE lock right now
 	 * in conn2, since the primary connection holds ACCESS EXCLUSIVE.
 	 */
-	printfStringInfo(&sql, "LOCK TABLE %s IN ACCESS SHARE MODE",
+	printfStringInfo(&sql, "LOCK TABLE %s IN SHARE UPDATE EXCLUSIVE MODE",
 					 table->target_name);
-	elog(DEBUG2, "LOCK TABLE %s IN ACCESS SHARE MODE", table->target_name);
+	elog(DEBUG2, "LOCK TABLE %s IN SHARE UPDATE EXCLUSIVE MODE", table->target_name);
 	if (PQsetnonblocking(conn2, 1))
 	{
 		elog(WARNING, "Unable to set conn2 nonblocking.");
@@ -1465,7 +1465,7 @@ repack_one_table(repack_table *table, const char *orderby)
 	 */
 	while ((res = PQgetResult(conn2)))
 	{
-		elog(DEBUG2, "Waiting on ACCESS SHARE lock...");
+		elog(DEBUG2, "Waiting on SHARE UPDATE EXCLUSIVE lock...");
 		if (PQresultStatus(res) != PGRES_COMMAND_OK)
 		{
 			elog(WARNING, "Error with LOCK TABLE: %s", PQerrorMessage(conn2));
@@ -1617,7 +1617,7 @@ repack_one_table(repack_table *table, const char *orderby)
 	 *    AccessShare lock.
 	 */
 	elog(DEBUG2, "---- swap ----");
-	/* Bump our existing AccessShare lock to AccessExclusive */
+	/* Bump our existing ShareUpdateExclusive lock to AccessExclusive */
 
 	if (!(lock_exclusive(conn2, utoa(table->target_oid, buffer),
 						 table->lock_table, false)))

--- a/doc/pg_repack.rst
+++ b/doc/pg_repack.rst
@@ -427,10 +427,9 @@ pg_repack cannot cluster tables by GiST indexes.
 DDL commands
 ^^^^^^^^^^^^
 
-You will not be able to perform DDL commands of the target table(s) **except**
-VACUUM or ANALYZE while pg_repack is working. pg_repack will hold an
-ACCESS SHARE lock on the target table during a full-table repack, to enforce
-this restriction.
+You will not be able to perform DDL commands of the target table(s) while
+pg_repack is working. pg_repack will hold an SHARE UPDATE EXCLUSIVE lock on the
+target table during a full-table repack, to enforce this restriction.
 
 If you are using version 1.1.8 or earlier, you must not attempt to perform any
 DDL commands on the target table(s) while pg_repack is running. In many cases
@@ -457,8 +456,8 @@ To perform a full-table repack, pg_repack will:
 pg_repack will only hold an ACCESS EXCLUSIVE lock for a short period during
 initial setup (steps 1 and 2 above) and during the final swap-and-drop phase
 (steps 6 and 7). For the rest of its time, pg_repack only needs
-to hold an ACCESS SHARE lock on the original table, meaning INSERTs, UPDATEs,
-and DELETEs may proceed as usual.
+to hold an SHARE UPDATE EXCLUSIVE lock on the original table, meaning INSERTs,
+UPDATEs, and DELETEs may proceed as usual.
 
 
 Index Only Repacks

--- a/doc/pg_repack_jp.rst
+++ b/doc/pg_repack_jp.rst
@@ -774,10 +774,9 @@ pg_repackはGiSTインデックスを使ってテーブルを再編成するこ�
 .. DDL commands
   ^^^^^^^^^^^^
   
-  You will not be able to perform DDL commands of the target table(s) **except**
-  VACUUM or ANALYZE while pg_repack is working. pg_repack will hold an
-  ACCESS SHARE lock on the target table during a full-table repack, to enforce
-  this restriction.
+  You will not be able to perform DDL commands of the target table(s) while
+  pg_repack is working. pg_repack will hold an SHARE UPDATE EXCLUSIVE lock on the
+  target table during a full-table repack, to enforce this restriction.
   
   If you are using version 1.1.8 or earlier, you must not attempt to perform any
   DDL commands on the target table(s) while pg_repack is running. In many cases
@@ -787,9 +786,9 @@ pg_repackはGiSTインデックスを使ってテーブルを再編成するこ�
 DDLコマンド
 ^^^^^^^^^^^^
 
-pg_repackを実行している間、VACUUMもしくはANALYZE以外のDDLコマンドを対象の
+pg_repackを実行している間、DDLコマンドを対象の
 テーブルに対して実行することはできません。何故ならば、pg_repackは
-ACCESS SHAREロックを対象テーブルに対して保持しつづけるからです。
+SHARE UPDATE EXCLUSIVEロックを対象テーブルに対して保持しつづけるからです。
 
 バージョン1.1.8もしくはそれ以前のバージョンを使っている場合、あらゆるDDL
 コマンドをpg_repackが走っているテーブルに対して実行することができません。
@@ -818,8 +817,8 @@ ACCESS SHAREロックを対象テーブルに対して保持しつづけるか�
   pg_repack will only hold an ACCESS EXCLUSIVE lock for a short period during
   initial setup (steps 1 and 2 above) and during the final swap-and-drop phase
   (steps 6 and 7). For the rest of its time, pg_repack only needs
-  to hold an ACCESS SHARE lock on the original table, meaning INSERTs, UPDATEs,
-  and DELETEs may proceed as usual.
+  to hold an SHARE UPDATE EXCLUSIVE lock on the original table, meaning INSERTs,
+  UPDATEs, and DELETEs may proceed as usual.
 
 テーブル再編成
 ^^^^^^^^^^^^^^^
@@ -835,7 +834,7 @@ ACCESS SHAREロックを対象テーブルに対して保持しつづけるか�
 7. 元のテーブルを削除します
 
 pg_repackは上の手順の中で、始めの1.と2.の時点、および最後の6.と7.の時点で対象のテーブルに対する
-ACCESS EXCLUSIVEロックを取得します。その他のステップでは、ACCESS SHAREロックを必要とするだけなので、
+ACCESS EXCLUSIVEロックを取得します。その他のステップでは、SHARE UPDATE EXCLUSIVEロックを必要とするだけなので、
 元のテーブルに対するINSERT, UPDATE, DELETE操作は通常通りに実行されます。
 
 .. Index Only Repacks


### PR DESCRIPTION
Currently conn2 acquires `ACCESS SHARE` lock which allows to run concurrent DDL statements, like `CREATE INDEX CONCURRENTLY`.

Fix it by acquiring `SHARE UPDATE EXCLUSIVE` lock. This will also lock concurrent `VACUUM`, `ANALYZE` queries, locking them looks safer option anyway.

Thoughts?

Issue #420 