### PR TITLE
Issue #457: Move SAVEPOINT outside the retry loop and call RELEASE SAVEPOINT

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install additional build-dependencies for 18+
         if: ${{ matrix.pg >= 18 }}
-        run: apt-get install -y libcurl4-openssl-dev
+        run: apt-get install -y libcurl4-openssl-dev libnuma-dev
 
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/regress/expected/nosuper.out
+++ b/regress/expected/nosuper.out
@@ -21,11 +21,7 @@ GRANT USAGE ON SCHEMA repack TO nosuper;
 -- => ERROR
 \! pg_repack --dbname=contrib_regression --table=tbl_cluster --username=nosuper --no-superuser-check
 INFO: repacking table "public.tbl_cluster"
-ERROR: query failed: ERROR:  current transaction is aborted, commands ignored until end of transaction block
-DETAIL: query was: RESET lock_timeout
-ERROR: query failed: ERROR:  current transaction is aborted, commands ignored until end of transaction block
-DETAIL: query was: RESET lock_timeout
-ERROR:  permission denied for table tbl_cluster
+WARNING: lock_exclusive() failed for public.tbl_cluster
 ERROR:  permission denied for table tbl_cluster
 REVOKE ALL ON ALL TABLES IN SCHEMA repack FROM nosuper;
 REVOKE USAGE ON SCHEMA repack FROM nosuper;

--- a/regress/expected/nosuper_1.out
+++ b/regress/expected/nosuper_1.out
@@ -21,11 +21,7 @@ GRANT USAGE ON SCHEMA repack TO nosuper;
 -- => ERROR
 \! pg_repack --dbname=contrib_regression --table=tbl_cluster --username=nosuper --no-superuser-check
 INFO: repacking table "public.tbl_cluster"
-ERROR: query failed: ERROR:  current transaction is aborted, commands ignored until end of transaction block
-DETAIL: query was: RESET lock_timeout
-ERROR: query failed: ERROR:  current transaction is aborted, commands ignored until end of transaction block
-DETAIL: query was: RESET lock_timeout
-ERROR:  permission denied for relation tbl_cluster
+WARNING: lock_exclusive() failed for public.tbl_cluster
 ERROR:  permission denied for relation tbl_cluster
 REVOKE ALL ON ALL TABLES IN SCHEMA repack FROM nosuper;
 REVOKE USAGE ON SCHEMA repack FROM nosuper;


### PR DESCRIPTION
`lock_access_share()` and `lock_exclusive()` doesn't call RELEASE SAVEPOINT on every retry which pollutes the cache and degrades the performance. This commit calls RELEASE SAVEPOINT when created savepoint is not necessary anymore. Additionally it moves SAVEPOINT outside of the retry loop since it isn't necessary to create new savepoint on every retry at all.

`lock_exclusive()` also moves start of transaction outside of the retry loop and creates a savepoint regardless of the value `start_xact`.

Now Github workflow also installs `libnuma-dev` for PostgreSQL 18 since it has new option `--with-libnuma`:
https://www.postgresql.org/docs/18/release-18.html
> Add configure option --with-libnuma to enable NUMA awareness (Jakub Wartak, Bertrand Drouvot)

Issue #457 