### PR TITLE
Fix NOTICE suppression for pg_regress with PGAPPNAME

### DIFF
--- a/bin/pg_repack.c
+++ b/bin/pg_repack.c
@@ -71,7 +71,7 @@ const char *PROGRAM_VERSION = "unknown";
  * based on pg_backend_pid() and application_name), but that shouldn't hurt
  * anything. Also, the test of application_name is not bulletproof -- for
  * instance, the application name when running installcheck will be
- * pg_regress.
+ * pg_regress/<testname>, or just pg_regress on PostgreSQL <10.
  */
 #define SQL_XID_SNAPSHOT_90200 \
 	"SELECT coalesce(array_agg(l.virtualtransaction), '{}') " \
@@ -1238,7 +1238,8 @@ repack_one_table(repack_table *table, const char *orderby)
 	int             j;
 
 	/* appname will be "pg_repack" in normal use on 9.0+, or
-	 * "pg_regress" when run under `make installcheck`
+	 * "pg_regress/<testname>" when run under `make installcheck`
+	 * ("pg_regress" on PostgreSQL <10).
 	 */
 	const char     *appname = getenv("PGAPPNAME");
 
@@ -1593,7 +1594,9 @@ repack_one_table(repack_table *table, const char *orderby)
 			 * noise which would trip up pg_regress.
 			 */
 
-			if (!appname || strcmp(appname, "pg_regress") != 0)
+			if (!appname ||
+				(strncmp(appname, "pg_regress/", strlen("pg_regress/")) != 0 &&
+				 strcmp(appname, "pg_regress") != 0))
 			{
 				elog(NOTICE, "Waiting for %d transactions to finish. First PID: %s", num, PQgetvalue(res, 0, 0));
 			}


### PR DESCRIPTION
This PR fixes flaky regression tests caused by unsuppressed NOTICE messages
leaking into `make installcheck` output.

The NOTICE about waiting for transactions is meant to be suppressed when
running under pg_regress, but since PostgreSQL 10
(postgres/postgres@a4327296df7), pg_regress sets `PGAPPNAME` to
`pg_regress/<testname>` instead of just `pg_regress`. The existing
`strcmp` check only matched the exact string `"pg_regress"`, so the
suppression silently stopped working on PG 10+.

When a concurrent transaction happens to be present during the test run,
the NOTICE leaks into output and causes a spurious diff like:

```diff
@@ -380,6 +380,7 @@
 INFO: repacking table "public.child_a_2"
 INFO: repacking table "public.parent_a"
 INFO: repacking table "public.partition_a_1"
+NOTICE: Waiting for 1 transactions to finish. First PID: 572
 INFO: repacking table "public.partition_a_2"
```

- Match both `"pg_regress/<testname>"` (PG 10+) and bare `"pg_regress"` (PG <10) PGAPPNAME formats
- Update related comments to document both PGAPPNAME formats

Debugged and drafted the fix with assistance from Cursor IDE and Claude
claude-4.6-opus (Anthropic).
